### PR TITLE
Resolves gh-5: Adds support for building libstar and examples in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,17 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      # Install Build Dependencies
+      - name: Install Meson
+        uses: actions/setup-python@v1
+          with:
+            python-version: '3.x'
+        uses: BSFishy/pip-action@v1
+          with:
+            packages: |
+              meson
+              ninja
+
       # Checkout
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,26 @@
+name: build-and-run
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # Build libstar with Meson
+      - name: meson build
+        uses: actions/checkout@v2
+        run: |
+          cd libstar
+          meson setup build
+          meson compile -C build
+
+      # Run examples
+      - name: run console example
+        run: |
+          ./libstar/build/libstar-console-example

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,9 +12,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      # Checkout
+      - name: Checkout
+        uses: actions/checkout@v2
+
       # Build libstar with Meson
       - name: meson build
-        uses: actions/checkout@v2
         run: |
           cd libstar
           meson setup build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: build-and-run
 on: [push, pull_request]
 
 jobs:
-  build:
+  build-libstar:
     strategy:
       fail-fast: false
       matrix:
@@ -34,7 +34,7 @@ jobs:
         run: |
           ./libstar/build/libstar-console-example
 
-  build-daisy:
+  build-daisy-host:
     runs-on: macos-latest
 
     steps:
@@ -47,7 +47,7 @@ jobs:
         run: |
           cd hosts/daisy/vendor/libDaisy
           make
-      - name: Build app
+      - name: Build Bluemchen example
         run: |
           cd hosts/daisy/examples/bluemchen
           make

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,20 +12,15 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      # Install Build Dependencies
-      - name: Install Meson
-        uses: actions/setup-python@v1
-          with:
-            python-version: '3.x'
-        uses: BSFishy/pip-action@v1
-          with:
-            packages: |
-              meson
-              ninja
-
-      # Checkout
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - uses: BSFishy/pip-action@v1
+        with:
+          packages: |
+            meson
+            ninja
 
       # Build libstar with Meson
       - name: meson build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,3 +33,21 @@ jobs:
       - name: run console example
         run: |
           ./libstar/build/libstar-console-example
+
+  build-daisy:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install ARM build toolchain
+        run: brew install gcc-arm-embedded
+
+      - name: Build libDaisy dependency
+        run: |
+          cd hosts/daisy/vendor/libDaisy
+          make
+      - name: Build app
+        run: |
+          cd hosts/daisy/examples/bluemchen
+          make

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ To compile to Daisy-based Eurorack modules:
 
 
 ## Language and Compiler Support
-Starling's core is written in C using the C99 standard (due to the use of C++ style comments, for loops with initial declarations, and float math functions like sinef and powf). It is currently compiled and tested on LLVM on macOS, GCC on Ubuntu Linux, and the Visual Studio C compiler on Windows.
+Starlings' core is written in C using the C99 standard (due to the use of C++ style comments, for loops with initial declarations, and float math functions like sinef and powf). It is currently compiled and tested on LLVM on macOS, GCC on Ubuntu Linux, and the Visual Studio C compiler on Windows.
 
-On the Daisy platform, Starling is compiled using Daisy's own toolchain, which uses the gnu11 standard for C and gnu++14 for C++. Compiling the Daisy Host and examples is currently supported using GCC on macOS.
+On the Daisy platform, Starlings is compiled using Daisy's own toolchain, which uses the gnu11 standard for C and gnu++14 for C++. Compiling the Daisy Host and examples is currently supported using GCC on macOS.
 
 ## Attribution
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ To compile to Daisy-based Eurorack modules:
 3. Open ```index.html``` using VS Code's LiveServer or other webserver
 
 #### Bluemchen Example
-1. ```cd hosts/daisy/examples/bluemchen```
+1. ```cd hosts/daisy/vendor/libDaisy```
+2. ```make```
+3. ```cd ../../examples/bluemchen```
 2. ```make```
 3. Use the [Daisy Web Programmer](https://electro-smith.github.io/Programmer/) to flash the ```build/libflock-bluemchen-example.bin``` binary to the Daisy board
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This project is an early-stage effort to rewrite and redesign the core signal pr
 
 * *Live repatching without compilation*: provide a highly mutable audio graph, so that instruments can be dynamically reconfigured while they are running (on platforms where this is appropriate).
 * *Vastly portable*: support deployment on the Web (via Web Assembly), desktop and mobile operating systems (macOS, Windows, Linux, iOS), specialized audio OS-based environments (Bela), and microcontroller-based systems (Daisy).
-* *Multirepresentational and openly authorable*: serve as a foundation for supporting [open authorial practices](https://github.com/amb26/papers/blob/master/onward-2016/onward-2016.pdf) while offering a very low-level signal graph data representation and API upon which more supportive abstractions can be layered.
 * *Fully externalized state*: Provide a means for [fully externalizing all state](http://openresearch.ocadu.ca/id/eprint/2059/1/Clark_sdr_2017_preprint.pdf) via a Nexus-like RESTful API, including:
     * Creating signals
     * Getting signal values/representations

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ To compile to Daisy-based Eurorack modules:
 2. ```make```
 3. Use the [Daisy Web Programmer](https://electro-smith.github.io/Programmer/) to flash the ```build/libflock-bluemchen-example.bin``` binary to the Daisy board
 
+
+## Language and Compiler Support
+Starling's core is written in C using the C99 standard (due to the use of C++ style comments, for loops with initial declarations, and float math functions like sinef and powf). It is currently compiled and tested on LLVM on macOS, GCC on Ubuntu Linux, and the Visual Studio C compiler on Windows.
+
+On the Daisy platform, Starling is compiled using Daisy's own toolchain, which uses the gnu11 standard for C and gnu++14 for C++. Compiling the Daisy Host and examples is currently supported using GCC on macOS.
+
 ## Attribution
 
 Starlings is developed by Colin Clark and is licenced under the [MIT License](LICENSE).

--- a/hosts/daisy/examples/bluemchen/Makefile
+++ b/hosts/daisy/examples/bluemchen/Makefile
@@ -1,11 +1,11 @@
 # Project Name
-TARGET ?= libflock-bluemchen-example
+TARGET ?= starlings-bluemchen-example
 
 DEBUG = 1
 OPT = -O0
 
 # Sources
-C_SOURCES = ../../../libflock/src/libflock.c
+C_SOURCES = ../../../../libstar/src/libstar.c
 CPP_SOURCES = vendor/kxmx_bluemchen/src/kxmx_bluemchen.cpp src/${TARGET}.cpp
 
 USE_FATFS = 1

--- a/hosts/daisy/examples/bluemchen/src/starlings-bluemchen-example.cpp
+++ b/hosts/daisy/examples/bluemchen/src/starlings-bluemchen-example.cpp
@@ -1,5 +1,5 @@
 #include "../vendor/kxmx_bluemchen/src/kxmx_bluemchen.h"
-#include "../../../../libflock/include/libflock.h"
+#include "../../../../libstar/include/libstar.h"
 #include <string>
 
 using namespace kxmx;
@@ -10,25 +10,30 @@ Parameter knob1;
 Parameter cv1;
 Parameter cv2;
 
-flock_sig_Value freqMod;
-flock_sig_Value ampMod;
-flock_sig_Sine carrier;
-flock_sig_Value gainValue;
-flock_sig_Gain gain;
+star_sig_Value freqMod;
+star_sig_Value ampMod;
+star_sig_Sine carrier;
+star_sig_Value gainValue;
+star_sig_Gain gain;
 
 void UpdateOled() {
     bluemchen.display.Fill(false);
     FixedCapStr<20> displayStr;
 
+    displayStr.Append("STARLINGS");
+    bluemchen.display.SetCursor(0, 0);
+    bluemchen.display.WriteString(displayStr.Cstr(), Font_6x8, true);
+
+    displayStr.Clear();
     displayStr.Append("A: ");
     displayStr.AppendFloat(cv1.Value(), 3);
-    bluemchen.display.SetCursor(0, 0);
+    bluemchen.display.SetCursor(0, 8);
     bluemchen.display.WriteString(displayStr.Cstr(), Font_6x8, true);
 
     displayStr.Clear();
     displayStr.Append("F: ");
     displayStr.AppendFloat(cv2.Value(), 3);
-    bluemchen.display.SetCursor(0, 8);
+    bluemchen.display.SetCursor(0, 16);
     bluemchen.display.WriteString(displayStr.Cstr(), Font_6x8, true);
 
     bluemchen.display.Update();
@@ -47,7 +52,7 @@ void AudioCallback(daisy::AudioHandle::InputBuffer in,
     gainValue.parameters.value = knob1.Value();
     ampMod.parameters.value = cv1.Value();
     ampMod.signal.generate(&ampMod);
-    freqMod.parameters.value = flock_midiToFreq(cv2.Value());
+    freqMod.parameters.value = star_midiToFreq(cv2.Value());
     freqMod.signal.generate(&freqMod);
     carrier.signal.generate(&carrier);
 
@@ -73,7 +78,7 @@ void initControls() {
 int main(void) {
     bluemchen.Init();
 
-    struct flock_AudioSettings audioSettings = {
+    struct star_AudioSettings audioSettings = {
         .sampleRate = bluemchen.AudioSampleRate(),
         .numChannels = 1,
         .blockSize = 1
@@ -88,39 +93,24 @@ int main(void) {
      **************/
 
     float freqModOutput[audioSettings.blockSize];
-    flock_Buffer_fillSilence(freqModOutput, audioSettings.blockSize);
-    flock_sig_Value_init(&freqMod, &audioSettings, freqModOutput);
+    star_Buffer_fillSilence(freqModOutput, audioSettings.blockSize);
+    star_sig_Value_init(&freqMod, &audioSettings, freqModOutput);
     freqMod.parameters.value = 440.0f;
 
     float ampModOutput[audioSettings.blockSize];
-    flock_Buffer_fillSilence(ampModOutput, audioSettings.blockSize);
-    // float ampModFreq[audioSettings.blockSize];
-    // flock_Buffer_fill(1.0f, ampModFreq, audioSettings.blockSize);
-    // float ampModPhaseOffset[audioSettings.blockSize];
-    // flock_Buffer_fill(0.0f, ampModPhaseOffset, audioSettings.blockSize);
-    // float ampModMul[audioSettings.blockSize];
-    // flock_Buffer_fill(1.0f, ampModMul, audioSettings.blockSize);
-    // float ampModAdd[audioSettings.blockSize];
-    // flock_Buffer_fill(0.0f, ampModAdd, audioSettings.blockSize);
-    // struct flock_sig_Sine_Inputs ampModInputs = {
-    //     .freq = ampModFreq,
-    //     .phaseOffset = ampModPhaseOffset,
-    //     .mul = ampModMul,
-    //     .add = ampModAdd
-    // };
-    // flock_sig_Sine_init(&ampMod, &audioSettings, &ampModInputs, ampModOutput);
-    flock_sig_Value_init(&ampMod, &audioSettings, ampModOutput);
+    star_Buffer_fillSilence(ampModOutput, audioSettings.blockSize);
+    star_sig_Value_init(&ampMod, &audioSettings, ampModOutput);
     ampMod.parameters.value = 1.0f;
 
     /****************
      * Sine Carrier *
      ****************/
     float phaseOffset[audioSettings.blockSize];
-    flock_Buffer_fill(0.0f, phaseOffset, audioSettings.blockSize);
+    star_Buffer_fill(0.0f, phaseOffset, audioSettings.blockSize);
     float add[audioSettings.blockSize];
-    flock_Buffer_fill(0.0f, add, audioSettings.blockSize);
+    star_Buffer_fill(0.0f, add, audioSettings.blockSize);
 
-    struct flock_sig_Sine_Inputs carrierInputs = {
+    struct star_sig_Sine_Inputs carrierInputs = {
         .freq = freqMod.signal.output,
         .phaseOffset = phaseOffset,
         .mul = ampMod.signal.output,
@@ -128,9 +118,9 @@ int main(void) {
     };
 
     float sineOutput[audioSettings.blockSize];
-    flock_Buffer_fillSilence(sineOutput, audioSettings.blockSize);
+    star_Buffer_fillSilence(sineOutput, audioSettings.blockSize);
 
-    flock_sig_Sine_init(&carrier,
+    star_sig_Sine_init(&carrier,
         &audioSettings, &carrierInputs, sineOutput);
 
     /********
@@ -140,18 +130,18 @@ int main(void) {
     // Bluemchen's output circuit clips as it approaches full gain,
     // so 0.85 seems to be around the practical maximum value.
     float gainValueOutput[audioSettings.blockSize];
-    flock_Buffer_fillSilence(gainValueOutput, audioSettings.blockSize);
-    flock_sig_Value_init(&gainValue, &audioSettings, gainValueOutput);
+    star_Buffer_fillSilence(gainValueOutput, audioSettings.blockSize);
+    star_sig_Value_init(&gainValue, &audioSettings, gainValueOutput);
     gainValue.parameters.value = 0.85f;
 
-    struct flock_sig_Gain_Inputs gainInputs = {
+    struct star_sig_Gain_Inputs gainInputs = {
         .gain = gainValue.signal.output,
         .source = carrier.signal.output
     };
 
     float gainOutput[audioSettings.blockSize];
-    flock_Buffer_fillSilence(gainOutput, audioSettings.blockSize);
-    flock_sig_Gain_init(&gain, &audioSettings, &gainInputs, gainOutput);
+    star_Buffer_fillSilence(gainOutput, audioSettings.blockSize);
+    star_sig_Gain_init(&gain, &audioSettings, &gainInputs, gainOutput);
 
     bluemchen.StartAudio(AudioCallback);
 

--- a/hosts/daisy/examples/bluemchen/vendor/README.md
+++ b/hosts/daisy/examples/bluemchen/vendor/README.md
@@ -1,4 +1,4 @@
 # Vendored Libraries
 
 1. kxmx_bluemchen, MIT License
-git subtree add --prefix=flocking-host-daisy/examples/bluemchen/vendor/kxmx_bluemchen https://github.com/recursinging/kxmx_bluemchen.git e698539df403f6141a178dce5783d3801355c1fa --squash
+git subtree add --prefix=hosts/daisy/examples/bluemchen/vendor/kxmx_bluemchen https://github.com/recursinging/kxmx_bluemchen.git e698539df403f6141a178dce5783d3801355c1fa --squash

--- a/libstar/include/libstar.h
+++ b/libstar/include/libstar.h
@@ -11,7 +11,7 @@ extern "C" {
 #include <math.h>
 
 static const float star_PI = 3.14159265358979323846f;
-static const float star_TWOPI = star_PI * 2.0f;
+static const float star_TWOPI = 6.28318530717958647693f;
 
 /**
  * Converts MIDI note numbers into frequencies in hertz.

--- a/libstar/include/libstar.h
+++ b/libstar/include/libstar.h
@@ -6,8 +6,8 @@ extern "C" {
 #endif
 
 // TODO: Doesn't exist in a non-Emcripten-compiled wasm environment.
-// Need to either switch to a faster custom approximation or
-// Build the wasm version with Emscripten.
+// Need to either switch to a faster custom approximation of sin()
+// and other functions, or build the wasm version with Emscripten.
 #include <math.h>
 
 static const float star_PI = 3.14159265358979323846f;

--- a/libstar/include/libstar.h
+++ b/libstar/include/libstar.h
@@ -10,7 +10,8 @@ extern "C" {
 // Build the wasm version with Emscripten.
 #include <math.h>
 
-static const float star_TWOPI = M_PI * 2.0f;
+static const float star_PI = 3.14159265358979323846f;
+static const float star_TWOPI = star_PI * 2.0f;
 
 /**
  * Converts MIDI note numbers into frequencies in hertz.

--- a/libstar/meson.build
+++ b/libstar/meson.build
@@ -27,5 +27,6 @@ libstar_dep = declare_dependency(
 executable(
     'libstar-console-example',
     'examples/console/src/print-sine.c',
-    dependencies: [libstar_dep]
+    dependencies: [libstar_dep],
+    link_args: '-lm'
 )

--- a/libstar/meson.build
+++ b/libstar/meson.build
@@ -1,7 +1,7 @@
 project(
     'libstar',
     'c',
-    default_options: ['c_std=c89']
+    default_options: ['c_std=c99']
 )
 project_description = 'A very portable music signal processing library.'
 

--- a/libstar/meson.build
+++ b/libstar/meson.build
@@ -1,7 +1,7 @@
 project(
     'libstar',
     'c',
-    default_options: ['c_std=c99']
+    default_options: ['c_std=c89']
 )
 project_description = 'A very portable music signal processing library.'
 

--- a/libstar/meson.build
+++ b/libstar/meson.build
@@ -14,7 +14,8 @@ source_files = [
 # libstar
 libstar_library = static_library(
     meson.project_name(),
-    source_files
+    source_files,
+    link_args: '-lm'
 )
 
 libstar_dep = declare_dependency(

--- a/libstar/src/libstar.c
+++ b/libstar/src/libstar.c
@@ -76,7 +76,7 @@ void star_sig_Sine_generate(void* self) {
     struct star_sig_Sine* this = (struct star_sig_Sine*) self;
 
     for (int i = 0; i < this->signal.audioSettings->blockSize; i++) {
-        float modulatedPhase = fmod(this->phaseAccumulator +
+        float modulatedPhase = fmodf(this->phaseAccumulator +
             this->inputs->phaseOffset[i], star_TWOPI);
 
         this->signal.output[i] = sinf(modulatedPhase) *

--- a/libstar/src/libstar.c
+++ b/libstar/src/libstar.c
@@ -23,7 +23,6 @@ void star_sig_Value_init(void* self,
     float* output) {
     struct star_sig_Value* this = (struct star_sig_Value*) self;
 
-    // TODO: memory allocation issues?
     struct star_sig_Value_Parameters params = {
         .value = 1.0
     };
@@ -59,7 +58,6 @@ void star_sig_Sine_init(void* self,
     float* output) {
     struct star_sig_Sine* this = (struct star_sig_Sine*) self;
 
-    // TODO: memory allocation issues?
     struct star_sig_Signal signal = {
         .audioSettings = settings,
         .output = output,
@@ -96,7 +94,6 @@ void star_sig_Gain_init(void* self,
     struct star_AudioSettings* settings, struct star_sig_Gain_Inputs* inputs, float* output) {
     struct star_sig_Gain* this = (struct star_sig_Gain*) self;
 
-    // TODO: memory allocation issues?
     struct star_sig_Signal signal = {
         .audioSettings = settings,
         .output = output,


### PR DESCRIPTION
This PR replaces #2, and in addition to various renaming and refinements, adds build support using Github Actions. This includes cross-platform builds of libstar and its example (on macOS, Linux, and Windows) and cross-compilation of the Bluemchen example app for Daisy hardware.