### PR TITLE
Resolves gh-34: Implements a Dust signal

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,10 +74,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install ARM build toolchain
+      - name: Install Daisy toolchain
         run: |
           git clone https://github.com/electro-smith/DaisyToolchain.git
-          cd DaisyToolchain
+          cd DaisyToolchain/macOS
           ./install.command
 
       - name: Build libDaisy dependency

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install ARM build toolchain
-        run: brew install gcc-arm-embedded
+        run: |
+          git clone https://github.com/electro-smith/DaisyToolchain.git
+          cd DaisyToolchain
+          ./install.command
 
       - name: Build libDaisy dependency
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,11 +74,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install Daisy toolchain
+      - name: Install ARM toolchain
+        # We only install ARM GCC, since we don't need the other
+        # tools in the Daisy Toolchain and they're slow to install.
         run: |
           git clone https://github.com/electro-smith/DaisyToolchain.git
           cd DaisyToolchain/macOS
-          ./install.command
+          brew install ./gcc-arm-embedded.rb --cask
 
       - name: Build libDaisy dependency
         run: |

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -73,6 +73,36 @@
         "showDevDebugOutput": true,
         "svdFile": "${workspaceRoot}/.vscode/STM32H750x.svd",
         "type": "cortex-debug"
+      },
+      {
+        "name": "Remote Bluemchen Dusting",
+        "configFiles": [
+          "interface/stlink.cfg",
+          "target/stm32h7x.cfg"
+        ],
+        "cwd": "${workspaceFolder}/hosts/daisy/examples/bluemchen/dusting",
+        "debuggerArgs": [
+          "-d",
+          "${workspaceRoot}/hosts/daisy/examples/bluemchen/dusting"
+        ],
+        "executable": "${workspaceRoot}/hosts/daisy/examples/bluemchen/dusting/build/starlings-bluemchen-dusting.elf",
+        "interface": "swd",
+        "openOCDLaunchCommands": [
+          "init",
+          "reset init"
+        ],
+        "preLaunchTask": "Debug Build Bluemchen Examples",
+        "preRestartCommands": [
+          "load",
+          "enable breakpoint",
+          "monitor reset"
+        ],
+        "request": "launch",
+        "runToMain": true,
+        "servertype": "openocd",
+        "showDevDebugOutput": true,
+        "svdFile": "${workspaceRoot}/.vscode/STM32H750x.svd",
+        "type": "cortex-debug"
       }
     ],
     "version": "0.2.0"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -141,6 +141,20 @@
             "type": "shell"
         },
         {
+            "label": "Build and Flash Bluemchen Dusting",
+            "options": {
+                "cwd": "${workspaceFolder}/hosts/daisy/examples/bluemchen/dusting"
+            },
+            "dependsOn": [
+                "Build Bluemchen Examples"
+            ],
+            "command": "make program",
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "type": "shell"
+        },
+        {
             "label": "Build libdaisy",
             "options": {
                 "cwd": "${workspaceFolder}/hosts/daisy/vendor/libDaisy/"

--- a/hosts/daisy/examples/bluemchen/Makefile
+++ b/hosts/daisy/examples/bluemchen/Makefile
@@ -1,7 +1,10 @@
 all:
 	$(MAKE) -C oscillator
 	$(MAKE) -C looper
+	$(MAKE) -C dusting
+
 
 clean:
 	$(MAKE) -C oscillator clean
 	$(MAKE) -C looper clean
+	$(MAKE) -C dusting clean

--- a/hosts/daisy/examples/bluemchen/dusting/Makefile
+++ b/hosts/daisy/examples/bluemchen/dusting/Makefile
@@ -1,0 +1,21 @@
+# Project Name
+TARGET ?= starlings-bluemchen-dusting
+
+DEBUG = 1
+OPT = -O0
+
+# Sources
+C_SOURCES += ../../../../../libstar/vendor/tlsf/tlsf.c ../../../../../libstar/src/libstar.c
+C_INCLUDES += -I../../../../../libstar/vendor/tlsf -I../../../../../libstar/include
+
+CPP_INCLUDES += -I../../src/include
+CPP_SOURCES = ../vendor/kxmx_bluemchen/src/kxmx_bluemchen.cpp src/${TARGET}.cpp
+
+USE_FATFS = 1
+
+# Library Locations
+LIBDAISY_DIR = ../../../vendor/libDaisy
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/hosts/daisy/examples/bluemchen/dusting/src/starlings-bluemchen-dusting.cpp
+++ b/hosts/daisy/examples/bluemchen/dusting/src/starlings-bluemchen-dusting.cpp
@@ -1,0 +1,88 @@
+#include "../../vendor/kxmx_bluemchen/src/kxmx_bluemchen.h"
+#include <tlsf.h>
+#include <libstar.h>
+#include <string>
+
+using namespace kxmx;
+using namespace daisy;
+
+Bluemchen bluemchen;
+Parameter densityKnob;
+
+FixedCapStr<20> displayStr;
+
+#define SIGNAL_HEAP_SIZE 1024 * 384
+char signalHeap[SIGNAL_HEAP_SIZE];
+struct star_Allocator allocator = {
+    .heapSize = SIGNAL_HEAP_SIZE,
+    .heap = (void*) signalHeap
+};
+
+struct star_sig_Value* density;
+struct star_sig_Dust* dust;
+
+void UpdateOled() {
+    bluemchen.display.Fill(false);
+
+    displayStr.Clear();
+    displayStr.Append("Dust Dust");
+    bluemchen.display.SetCursor(0, 0);
+    bluemchen.display.WriteString(displayStr.Cstr(), Font_6x8, true);
+    bluemchen.display.Update();
+}
+
+void UpdateControls() {
+    bluemchen.encoder.Debounce();
+    densityKnob.Process();
+}
+
+void AudioCallback(daisy::AudioHandle::InputBuffer in,
+    daisy::AudioHandle::OutputBuffer out, size_t size) {
+    UpdateControls();
+
+    density->parameters.value = densityKnob.Value();
+    density->signal.generate(density);
+    dust->signal.generate(dust);
+
+    // Copy mono buffer to stereo output.
+    for (size_t i = 0; i < size; i++) {
+        out[0][i] = dust->signal.output[i];
+        out[1][i] = dust->signal.output[i];
+    }
+}
+
+void initControls() {
+    densityKnob.Init(bluemchen.controls[bluemchen.CTRL_1],
+        1.0f/120.0f, 1000.0f, Parameter::LINEAR);
+}
+
+int main(void) {
+    bluemchen.Init();
+    star_Allocator_init(&allocator);
+
+    struct star_AudioSettings audioSettings = {
+        .sampleRate = bluemchen.AudioSampleRate(),
+        .numChannels = 1,
+        .blockSize = 48
+    };
+
+    bluemchen.SetAudioBlockSize(audioSettings.blockSize);
+    bluemchen.StartAdc();
+    initControls();
+
+    density = star_sig_Value_new(&allocator, &audioSettings);
+    density->parameters.value = 1.0f;
+
+    struct star_sig_Dust_Inputs dustInputs = {
+        .density = density->signal.output
+    };
+
+    dust = star_sig_Dust_new(&allocator, &audioSettings, &dustInputs);
+    dust->parameters.bipolar = 0.0f;
+
+    bluemchen.StartAudio(AudioCallback);
+
+    while (1) {
+        UpdateOled();
+    }
+}

--- a/hosts/daisy/examples/bluemchen/looper/src/starlings-bluemchen-looper.cpp
+++ b/hosts/daisy/examples/bluemchen/looper/src/starlings-bluemchen-looper.cpp
@@ -205,11 +205,9 @@ int main(void) {
             &audioSettings, 0.0f)
     };
 
-    struct star_sig_Accumulate_Parameters speedControlParams = {
-        .accumulatorStart = 1.0f
-    };
     speedControl = star_sig_Accumulate_new(&allocator, &audioSettings,
-        &speedControlInputs, speedControlParams);
+        &speedControlInputs);
+    speedControl->parameters.accumulatorStart = 1.0f;
 
     speedMod = star_sig_Value_new(&allocator, &audioSettings);
     speedMod->parameters.value = 0.0f;

--- a/hosts/daisy/examples/bluemchen/oscillator/src/starlings-bluemchen-oscillator.cpp
+++ b/hosts/daisy/examples/bluemchen/oscillator/src/starlings-bluemchen-oscillator.cpp
@@ -11,6 +11,8 @@ Parameter knob1;
 Parameter cv1;
 Parameter cv2;
 
+FixedCapStr<20> displayStr;
+
 #define HEAP_SIZE 1024 * 256 // 256KB
 char heap[HEAP_SIZE];
 struct star_Allocator allocator = {
@@ -26,9 +28,9 @@ struct star_sig_Gain* gain;
 
 void UpdateOled() {
     bluemchen.display.Fill(false);
-    FixedCapStr<20> displayStr;
 
-    displayStr.Append("STARSCILL");
+    displayStr.Clear();
+    displayStr.Append("Starscill");
     bluemchen.display.SetCursor(0, 0);
     bluemchen.display.WriteString(displayStr.Cstr(), Font_6x8, true);
 

--- a/libstar/include/libstar.h
+++ b/libstar/include/libstar.h
@@ -64,6 +64,13 @@ float star_fmaxf(float a, float b);
 float star_clamp(float value, float min, float max);
 
 /**
+ * Generates a random float between 0.0 and 1.0.
+ *
+ * @return a random value
+ */
+float star_randf();
+
+/**
  * Converts MIDI note numbers into frequencies in hertz.
  * This algorithm assumes A4 = 440 Hz = MIDI note #69.
  *
@@ -367,13 +374,11 @@ struct star_sig_Accumulate {
 struct star_sig_Accumulate* star_sig_Accumulate_new(
     struct star_Allocator* allocator,
     struct star_AudioSettings* settings,
-    struct star_sig_Accumulate_Inputs* inputs,
-    struct star_sig_Accumulate_Parameters parameters);
+    struct star_sig_Accumulate_Inputs* inputs);
 void star_sig_Accumulate_init(
     struct star_sig_Accumulate* self,
     struct star_AudioSettings* settings,
     struct star_sig_Accumulate_Inputs* inputs,
-    struct star_sig_Accumulate_Parameters parameters,
     float_array_ptr output);
 void star_sig_Accumulate_generate(void* signal);
 void star_sig_Accumulate_destroy(struct star_Allocator* allocator,
@@ -640,6 +645,52 @@ struct star_sig_Looper* star_sig_Looper_new(
 void star_sig_Looper_generate(void* signal);
 void star_sig_Looper_destroy(struct star_Allocator* allocator,
     struct star_sig_Looper* self);
+
+struct star_sig_Dust_Parameters {
+    float bipolar;
+};
+
+struct star_sig_Dust_Inputs {
+    float_array_ptr density;
+};
+
+/**
+ * Generates random impulses.
+ *
+ * If the bipolar parameter is set to 0 (the default),
+ * the output will be in the range of 0 to 1.
+ * If bipolar >0, impulses between -1 and 1 will be generated.
+ *
+ * Inputs:
+ * - density: the number of impulses per second
+ *
+ * Parameters:
+ * - bipolar: the output will be unipolar if <=0, bipolar if >0
+ */
+struct star_sig_Dust {
+    struct star_sig_Signal signal;
+    struct star_sig_Dust_Inputs* inputs;
+    struct star_sig_Dust_Parameters parameters;
+
+    // TODO: Should this be part of AudioSettings?
+    float sampleDuration;
+
+    float previousDensity;
+    float threshold;
+    float scale;
+};
+
+void star_sig_Dust_init(struct star_sig_Dust* self,
+    struct star_AudioSettings* settings,
+    struct star_sig_Dust_Inputs* inputs,
+    float_array_ptr output);
+struct star_sig_Dust* star_sig_Dust_new(
+    struct star_Allocator* allocator,
+    struct star_AudioSettings* settings,
+    struct star_sig_Dust_Inputs* inputs);
+void star_sig_Dust_generate(void* signal);
+void star_sig_Dust_destroy(struct star_Allocator* allocator,
+    struct star_sig_Dust* self);
 
 #ifdef __cplusplus
 }

--- a/libstar/setup-emscripten-env.sh
+++ b/libstar/setup-emscripten-env.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-export EM_BINARYEN_ROOT=/opt/homebrew/opt/binaryen
 export EMSCRIPTEN_TOOLS_PATH=../../emscripten/tools

--- a/libstar/tests/test-libstar.c
+++ b/libstar/tests/test-libstar.c
@@ -160,24 +160,31 @@ void test_star_randf(void) {
     size_t numSamples = 8192;
 
     // Values should be within 0.0 to 1.0
-    float firstRun[numSamples];
-    fillBufferRandom(firstRun, numSamples);
-    testAssertBufferValuesInRange(firstRun, numSamples, 0.0f, 1.0f);
+    struct star_Buffer* firstRun = star_Buffer_new(&allocator,
+        numSamples);
+    fillBufferRandom(firstRun->samples, numSamples);
+    testAssertBufferValuesInRange(firstRun->samples, numSamples,
+        0.0f, 1.0f);
 
     // Consecutive runs should contain different values.
-    float secondRun[numSamples];
-    fillBufferRandom(secondRun, numSamples);
-    testAssertBuffersNotEqual(firstRun, secondRun, numSamples);
+    struct star_Buffer* secondRun = star_Buffer_new(&allocator,
+        numSamples);
+    fillBufferRandom(secondRun->samples, numSamples);
+    testAssertBuffersNotEqual(firstRun->samples, secondRun->samples,
+        numSamples);
 
     // Using the same seed for each run
     // should produce identical results.
-    float thirdRun[numSamples];
-    float fourthRun[numSamples];
+    struct star_Buffer* thirdRun = star_Buffer_new(&allocator,
+        numSamples);
+    struct star_Buffer* fourthRun = star_Buffer_new(&allocator,
+        numSamples);
     srand(1);
-    fillBufferRandom(thirdRun, numSamples);
+    fillBufferRandom(thirdRun->samples, numSamples);
     srand(1);
-    fillBufferRandom(fourthRun, numSamples);
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(thirdRun, fourthRun, numSamples);
+    fillBufferRandom(fourthRun->samples, numSamples);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(thirdRun->samples,
+        fourthRun->samples, numSamples);
 }
 
 void test_star_Audio_Block_newWithValue_testForValue(


### PR DESCRIPTION
This PR contains a new implementation of Dust that can produce both unipolar and bipolar outputs. The current implementation depends on the stdlib's ```rand()``` implementation, but a custom RNG should be considered at some point (see #35).