### PR TITLE
Resolves gh-18: Adds Docker build process for all cross-compiled targets

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,6 @@ jobs:
           packages: |
             meson
             ninja
-      - uses: mymindstorm/setup-emsdk@v11
 
       - name: Prepare MSVC (Windows-only)
         if: runner.os == 'Windows'
@@ -34,38 +33,42 @@ jobs:
           meson setup build/native
           meson compile -C build/native
 
-      # Build libsignaletic for wasm
-      # TODO: Windows can't run generate-wasm-bindings.sh;
-      # need to add cross-platform support for it.
-      # This will be fixed by gh-18 (Docker support)
-      - name: Web Assembly build
-        if: runner.os != 'Windows'
-        run: |
-          git clone https://github.com/emscripten-core/emscripten.git
-          export EMSCRIPTEN_TOOLS_PATH=$PWD/emscripten/tools
-          cd libsignaletic
-          meson setup build/wasm --cross-file wasm-cross-compile.txt
-          ./generate-wasm-bindings.sh
-          meson compile -C build/wasm
-
       # Tests
       - name: Run native unit tests
         run: |
           cd libsignaletic
           meson test -C build/native -v
 
-      - name: Run unit tests in Node.js
-        if: runner.os != 'Windows'
-        run: |
-          cd libsignaletic
-          meson test -C build/wasm -v
-
       # Run examples
       - name: run console example
         run: ./libsignaletic/build/native/libsignaletic-console-example
 
+  build-wasm:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - uses: BSFishy/pip-action@v1
+        with:
+          packages: |
+            meson
+            ninja
+      - uses: mymindstorm/setup-emsdk@v11
+
+      - name: Web Assembly build
+        run: |
+          cd libsignaletic
+          ./build-libsignaletic-wasm.sh
+
+      - name: Run unit tests in Node.js
+        run: |
+          cd libsignaletic
+          meson test -C build/wasm -v
+
       - name: run console example in Node.js
-        if: runner.os != 'Windows'
         run: node ./libsignaletic/build/wasm/libsignaletic-console-example.js
 
   build-daisy-host:
@@ -82,11 +85,7 @@ jobs:
           cd DaisyToolchain/macOS
           brew install ./gcc-arm-embedded.rb --cask
 
-      - name: Build libDaisy dependency
+      - name: Build Daisy Host and Examples
         run: |
-          cd hosts/daisy/vendor/libDaisy
-          make
-      - name: Build Bluemchen example
-        run: |
-          cd hosts/daisy/examples/bluemchen
-          make
+          cd hosts/daisy
+          ./build-all-daisy.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM emscripten/emsdk:latest
+
+RUN apt update && apt install -y python3 python3-pip \
+python3-setuptools python3-wheel ninja-build
+RUN pip3 install meson
+
+WORKDIR /gcc-arm
+RUN wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2
+RUN tar -xf gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2
+
+ENV GCC_PATH=/gcc-arm/gcc-arm-none-eabi-10-2020-q4-major/bin
+RUN export PATH=$GCC_PATH:$PATH
+RUN echo $GCC_PATH
+
+WORKDIR /signaletic

--- a/README.md
+++ b/README.md
@@ -37,14 +37,11 @@ The design of this project is still in flux, and will more fully emerge as I bec
 2. ```xcode-select --install```
 
 #### libsignaletic Web Assembly
-libsignaletic uses the [Emscripten compiler](https://emscripten.org/) for Web Assembly support. This installation process is no fun, and could use some improvement.
-1. ```brew install emscripten binaryen```
-2. ```export EM_BINARYEN_ROOT=/opt/homebrew/opt/binaryen```
-3. Clone the [emscripten repository](https://github.com/emscripten-core/emscripten).
-4. ```export EMSCRIPTEN_TOOLS_PATH=[path to emscripten repository]/tools```
+libsignaletic uses the [Emscripten compiler](https://emscripten.org/) for Web Assembly support. Docker is used to support cross-platform builds.
+1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 
 #### Daisy Eurorack Examples
-To cross-compile the Signaletic examples for the Daisy STM32 platform using gcc and make, the GCC ARM embedded toolkit and the Daisy Toolchain must be installed.
+Docker is also used to cross-compile the Signaletic examples for embedded platforms such as the Daisy STM32 platform. If you want to build these directly on your host using gcc and make, the GCC ARM embedded toolkit and the Daisy Toolchain must be installed.
 1. ```brew install gcc-arm-embedded```
 2. Follow the [Daisy Toolchain](https://github.com/electro-smith/DaisyWiki/wiki/1.-Setting-Up-Your-Development-Environment#1-install-the-toolchain) installation instructions.
 
@@ -52,6 +49,7 @@ To cross-compile the Signaletic examples for the Daisy STM32 platform using gcc 
 1. Install Meson using the [Meson Installer](https://github.com/mesonbuild/meson/releases)
 2. Install Emscripten according to the [Emscripten installation documentation](https://emscripten.org/docs/getting_started/downloads.html)
 3. Install the [Daisy Toolchain for Windows](https://github.com/electro-smith/DaisyWiki/wiki/1c.-Installing-the-Toolchain-on-Windows)
+4. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 
 ## Building Signaletic
 
@@ -66,13 +64,10 @@ On Windows, use a VS Command Prompt or set the appropriate environment variables
 
 To remove all previous build artifacts and rebuild, run ```rm -r build/native && meson setup build/native``` or run ```meson setup build/native --wipe```.
 
-#### libsignaletic for Web Assembly (not currently supported on Windows)
-1. ```cd libsignaletic```
-2. ```source ../../emsdk/emsdk_env.sh```
-3. ```source ./setup-emscripten-env.sh```
-4. ```meson setup build/wasm --cross-file wasm-cross-compile.txt```
-5. ```./generate-wasm-bindings.sh```
-6. ```meson compile -C build/wasm```
+#### libsignaletic for Web Assembly
+At the root of the Signaletic repository:
+1. Build the Docker image: ```docker build . -t signaletic```
+2. Run the cross-compilation script in Docker: ```docker run --platform=linux/amd64 -v `pwd`:/signaletic signaletic /signaletic/cross-build-all.sh```
 
 #### Running the Unit Tests
 1. Native: ```meson test -C build/native -v```
@@ -93,11 +88,8 @@ To remove all previous build artifacts and rebuild, run ```rm -r build/native &&
 ##### Daisy Bluemchen Example
 On Windows, use a Git Bash terminal, since Daisy's Makefiles don't seem to provide Windows support.
 
-1. ```cd hosts/daisy/vendor/libDaisy```
-2. ```make```
-3. ```cd ../../examples/bluemchen/looper```
-2. ```make```
-3. Use the [Daisy Web Programmer](https://electro-smith.github.io/Programmer/) to flash the ```build/signaletic-bluemchen-looper.bin``` binary to the Daisy board, or run ```make program``` while connected to an ST-Link Mini debugger.
+1. ```docker run --platform=linux/amd64 -v `pwd`:/signaletic signaletic /signaletic/cross-build-all.sh```
+2. Use the [Daisy Web Programmer](https://electro-smith.github.io/Programmer/) to flash the ```build/signaletic-bluemchen-looper.bin``` binary to the Daisy board, or run ```make program``` while connected to an ST-Link Mini debugger.
 
 
 ## Language and Compiler Support

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ At the root of the Signaletic repository:
 
 #### Running the Unit Tests
 1. Native: ```meson test -C build/native -v```
-2. Node.js wasm: ```meson test -C build/wasm -v```
+2. Node.js wasm: ```node build/wasm/run_tests.js```
 3. Browser wasm: Open ```libsignaletic/tests/test-libsignaletic.html``` using VS Code's Live Server plugin or other web server.
 
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,7 @@ Docker is also used to cross-compile the Signaletic examples for embedded platfo
 
 ### Windows
 1. Install Meson using the [Meson Installer](https://github.com/mesonbuild/meson/releases)
-2. Install Emscripten according to the [Emscripten installation documentation](https://emscripten.org/docs/getting_started/downloads.html)
-3. Install the [Daisy Toolchain for Windows](https://github.com/electro-smith/DaisyWiki/wiki/1c.-Installing-the-Toolchain-on-Windows)
-4. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+2. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 
 ## Building Signaletic
 
@@ -85,11 +83,10 @@ At the root of the Signaletic repository:
 1. Build libsignaletic Web Assembly
 2. Open ```hosts/web/examples/midi-to-freq/index.html``` using VS Code's Live Server plugin or other web server.
 
-##### Daisy Bluemchen Example
-On Windows, use a Git Bash terminal, since Daisy's Makefiles don't seem to provide Windows support.
-
-1. ```docker run --platform=linux/amd64 -v `pwd`:/signaletic signaletic /signaletic/cross-build-all.sh```
-2. Use the [Daisy Web Programmer](https://electro-smith.github.io/Programmer/) to flash the ```build/signaletic-bluemchen-looper.bin``` binary to the Daisy board, or run ```make program``` while connected to an ST-Link Mini debugger.
+##### Daisy Bluemchen Examples
+1. If you haven't already, build the Docker image ```docker build . -t signaletic```
+2. ```docker run --platform=linux/amd64 -v `pwd`:/signaletic signaletic /signaletic/cross-build-all.sh```
+3. Use the [Daisy Web Programmer](https://electro-smith.github.io/Programmer/) to flash the ```build/signaletic-bluemchen-looper.bin``` binary to the Daisy board, or run ```make program``` while connected to an ST-Link Mini debugger.
 
 
 ## Language and Compiler Support

--- a/cross-build-all.sh
+++ b/cross-build-all.sh
@@ -1,10 +1,9 @@
 #!/bin/sh
 
-# Build wasm version of Signaletic
+# Build Web Assembly version of Signaletic
 cd libsignaletic
 ./build-libsignaletic-wasm.sh
 
 # Cross-compile non-native host examples
-echo "\nCompiling Daisy Examples"
-cd ../hosts/daisy/examples/bluemchen
-make
+cd ../hosts/daisy
+./build-all-daisy.sh

--- a/cross-build-all.sh
+++ b/cross-build-all.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Build wasm version of Signaletic
+cd libsignaletic
+./build-libsignaletic-wasm.sh
+
+# Cross-compile non-native host examples
+echo "\nCompiling Daisy Examples"
+cd ../hosts/daisy/examples/bluemchen
+make

--- a/hosts/daisy/build-all-daisy.sh
+++ b/hosts/daisy/build-all-daisy.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo "\nCompiling libDaisy"
+cd vendor/libDaisy
+make
+
+echo "\nCompiling Daisy Examples"
+cd ../../examples/bluemchen
+make

--- a/libsignaletic/build-libsignaletic-wasm.sh
+++ b/libsignaletic/build-libsignaletic-wasm.sh
@@ -1,0 +1,11 @@
+echo "\nGenerating Web Assembly Bindings"
+mkdir -p build/bindings
+$EMSDK/upstream/emscripten/tools/webidl_binder wasm/bindings/libsignaletic-web-bindings.idl build/bindings/libsignaletic-web-bindings
+
+echo "\nCompiling Web Assembly"
+if [ ! -d "build/wasm" ]
+then
+    meson setup build/wasm --cross-file=wasm-cross-compile.txt
+fi
+
+meson compile -C build/wasm

--- a/libsignaletic/generate-wasm-bindings.sh
+++ b/libsignaletic/generate-wasm-bindings.sh
@@ -2,4 +2,4 @@
 
 mkdir -p build/bindings
 
-$EMSCRIPTEN_TOOLS_PATH/webidl_binder wasm/bindings/libsignaletic-web-bindings.idl build/bindings/libsignaletic-web-bindings
+$EMSDK/upstream/emscripten/tools/webidl_binder wasm/bindings/libsignaletic-web-bindings.idl build/bindings/libsignaletic-web-bindings

--- a/libsignaletic/generate-wasm-bindings.sh
+++ b/libsignaletic/generate-wasm-bindings.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-mkdir -p build/bindings
-
-$EMSDK/upstream/emscripten/tools/webidl_binder wasm/bindings/libsignaletic-web-bindings.idl build/bindings/libsignaletic-web-bindings

--- a/libsignaletic/setup-emscripten-env.sh
+++ b/libsignaletic/setup-emscripten-env.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-export EMSCRIPTEN_TOOLS_PATH=../../emscripten/tools


### PR DESCRIPTION
This PR introduces a Docker build file and new set of scripts for building the Web Assembly version of libsignaletic, as well as the arm-none Daisy code. It should make it a little easier for developers to build Signaletic in its various forms across different platforms.