### PR TITLE
Resolves gh-44: Refactors the Allocator API to be more amenable to custom implementations

### DIFF
--- a/docs/contributing/developing-a-signal.md
+++ b/docs/contributing/developing-a-signal.md
@@ -55,8 +55,8 @@ struct sig_dsp_${SignalName}* sig_dsp_${SignalName}_new(
     struct sig_AudioSettings* settings,
     struct sig_dsp_${SignalName}_Inputs* inputs) {
     float_array_ptr output = sig_AudioBlock_new(allocator, settings);
-    struct sig_dsp_${SignalName}* self = sig_Allocator_malloc(allocator,
-        sizeof(struct sig_dsp_${SignalName}));
+    struct sig_dsp_${SignalName}* self = allocator->impl->malloc(
+        allocator, sizeof(struct sig_dsp_${SignalName}));
     sig_dsp_${SignalName}_init(self, settings, inputs, output);
 
     return self;

--- a/hosts/daisy/examples/bluemchen/dusting/src/signaletic-nehcmeulb-dusting.cpp
+++ b/hosts/daisy/examples/bluemchen/dusting/src/signaletic-nehcmeulb-dusting.cpp
@@ -14,10 +14,17 @@ Parameter durationKnob;
 FixedCapStr<20> displayStr;
 
 #define SIGNAL_HEAP_SIZE 1024 * 384
-char signalHeap[SIGNAL_HEAP_SIZE];
+
+char memory[SIGNAL_HEAP_SIZE];
+
+struct sig_AllocatorHeap heap = {
+    .length = SIGNAL_HEAP_SIZE,
+    .memory = memory
+};
+
 struct sig_Allocator allocator = {
-    .heapSize = SIGNAL_HEAP_SIZE,
-    .heap = (void*) signalHeap
+    .impl = &sig_TLSFAllocatorImpl,
+    .heap = &heap
 };
 
 struct sig_dsp_Value* density;
@@ -103,7 +110,7 @@ void initControls() {
 
 int main(void) {
     bluemchen.Init();
-    sig_Allocator_init(&allocator);
+    allocator.impl->init(allocator.heap);
 
     struct sig_AudioSettings audioSettings = {
         .sampleRate = bluemchen.AudioSampleRate(),

--- a/hosts/daisy/examples/bluemchen/dusting/src/signaletic-nehcmeulb-dusting.cpp
+++ b/hosts/daisy/examples/bluemchen/dusting/src/signaletic-nehcmeulb-dusting.cpp
@@ -15,11 +15,11 @@ FixedCapStr<20> displayStr;
 
 #define SIGNAL_HEAP_SIZE 1024 * 384
 
-char memory[SIGNAL_HEAP_SIZE];
+char heapMemory[SIGNAL_HEAP_SIZE];
 
 struct sig_AllocatorHeap heap = {
     .length = SIGNAL_HEAP_SIZE,
-    .memory = memory
+    .memory = heapMemory
 };
 
 struct sig_Allocator allocator = {

--- a/hosts/daisy/examples/bluemchen/dusting/src/signaletic-nehcmeulb-dusting.cpp
+++ b/hosts/daisy/examples/bluemchen/dusting/src/signaletic-nehcmeulb-dusting.cpp
@@ -110,7 +110,7 @@ void initControls() {
 
 int main(void) {
     bluemchen.Init();
-    allocator.impl->init(allocator.heap);
+    allocator.impl->init(&allocator);
 
     struct sig_AudioSettings audioSettings = {
         .sampleRate = bluemchen.AudioSampleRate(),

--- a/hosts/daisy/examples/bluemchen/looper/src/signaletic-bluemchen-looper.cpp
+++ b/hosts/daisy/examples/bluemchen/looper/src/signaletic-bluemchen-looper.cpp
@@ -164,7 +164,7 @@ void initControls() {
 
 int main(void) {
     bluemchen.Init();
-    allocator.impl->init(allocator.heap);
+    allocator.impl->init(&allocator);
 
     struct sig_AudioSettings audioSettings = {
         .sampleRate = bluemchen.AudioSampleRate(),

--- a/hosts/daisy/examples/bluemchen/looper/src/signaletic-bluemchen-looper.cpp
+++ b/hosts/daisy/examples/bluemchen/looper/src/signaletic-bluemchen-looper.cpp
@@ -15,10 +15,15 @@ Parameter skewCV;
 Parameter recordGateCV;
 
 #define SIGNAL_HEAP_SIZE 1024 * 384
-char signalHeap[SIGNAL_HEAP_SIZE];
+char signalMemory[SIGNAL_HEAP_SIZE];
+struct sig_AllocatorHeap heap = {
+    .length = SIGNAL_HEAP_SIZE,
+    .memory = (void*) signalMemory
+};
+
 struct sig_Allocator allocator = {
-    .heapSize = SIGNAL_HEAP_SIZE,
-    .heap = (void*) signalHeap
+    .impl = &sig_TLSFAllocatorImpl,
+    .heap = &heap
 };
 
 #define LOOP_TIME_SECS 60
@@ -159,7 +164,7 @@ void initControls() {
 
 int main(void) {
     bluemchen.Init();
-    sig_Allocator_init(&allocator);
+    allocator.impl->init(allocator.heap);
 
     struct sig_AudioSettings audioSettings = {
         .sampleRate = bluemchen.AudioSampleRate(),

--- a/hosts/daisy/examples/bluemchen/oscillator/src/signaletic-bluemchen-oscillator.cpp
+++ b/hosts/daisy/examples/bluemchen/oscillator/src/signaletic-bluemchen-oscillator.cpp
@@ -97,7 +97,7 @@ void initControls() {
 
 int main(void) {
     bluemchen.Init();
-    allocator.impl->init(allocator.heap);
+    allocator.impl->init(&allocator);
 
     struct sig_AudioSettings audioSettings = {
         .sampleRate = bluemchen.AudioSampleRate(),

--- a/hosts/daisy/examples/bluemchen/oscillator/src/signaletic-bluemchen-oscillator.cpp
+++ b/hosts/daisy/examples/bluemchen/oscillator/src/signaletic-bluemchen-oscillator.cpp
@@ -14,10 +14,15 @@ Parameter cv2;
 FixedCapStr<20> displayStr;
 
 #define HEAP_SIZE 1024 * 256 // 256KB
-char heap[HEAP_SIZE];
+uint8_t memory[HEAP_SIZE];
+struct sig_AllocatorHeap heap = {
+    .length = HEAP_SIZE,
+    .memory = (void*) memory
+};
+
 struct sig_Allocator allocator = {
-    .heapSize = HEAP_SIZE,
-    .heap = (void*) heap
+    .impl = &sig_TLSFAllocatorImpl,
+    .heap = &heap
 };
 
 struct sig_dsp_Value* freqMod;
@@ -92,7 +97,7 @@ void initControls() {
 
 int main(void) {
     bluemchen.Init();
-    sig_Allocator_init(&allocator);
+    allocator.impl->init(allocator.heap);
 
     struct sig_AudioSettings audioSettings = {
         .sampleRate = bluemchen.AudioSampleRate(),

--- a/hosts/daisy/include/cc-signals.h
+++ b/hosts/daisy/include/cc-signals.h
@@ -40,11 +40,11 @@ struct cc_sig_DustGate* cc_sig_DustGate_new(
     cc_sig_DustGate_Inputs* inputs) {
 
     struct cc_sig_DustGate* self =
-        (cc_sig_DustGate*) allocator->impl->malloc(allocator->heap,
+        (cc_sig_DustGate*) allocator->impl->malloc(allocator,
         sizeof(struct cc_sig_DustGate));
 
     struct sig_dsp_Dust_Inputs* dustInputs = (struct sig_dsp_Dust_Inputs*)
-        allocator->impl->malloc(allocator->heap,
+        allocator->impl->malloc(allocator,
             sizeof(struct sig_dsp_Dust_Inputs));
     dustInputs->density = inputs->density;
 
@@ -53,7 +53,7 @@ struct cc_sig_DustGate* cc_sig_DustGate_new(
 
     struct sig_dsp_BinaryOp_Inputs* reciprocalDensityInputs =
         (struct sig_dsp_BinaryOp_Inputs*) allocator->impl->malloc(
-            allocator->heap, sizeof(struct sig_dsp_BinaryOp_Inputs));
+            allocator, sizeof(struct sig_dsp_BinaryOp_Inputs));
     reciprocalDensityInputs->left =
         sig_AudioBlock_newWithValue(allocator, audioSettings, 1.0f);
     reciprocalDensityInputs->right = inputs->density;
@@ -63,7 +63,7 @@ struct cc_sig_DustGate* cc_sig_DustGate_new(
 
     struct sig_dsp_BinaryOp_Inputs* densityDurationMuliplierInputs =
         (struct sig_dsp_BinaryOp_Inputs*)
-            allocator->impl->malloc(allocator->heap,
+            allocator->impl->malloc(allocator,
                 sizeof(struct sig_dsp_BinaryOp_Inputs));
     densityDurationMuliplierInputs->left =
         self->reciprocalDensity->signal.output;
@@ -74,7 +74,7 @@ struct cc_sig_DustGate* cc_sig_DustGate_new(
 
     struct sig_dsp_TimedGate_Inputs* gateInputs =
         (struct sig_dsp_TimedGate_Inputs*) allocator->impl->malloc(
-            allocator->heap,
+            allocator,
             sizeof(struct sig_dsp_TimedGate_Inputs));
     gateInputs->trigger =self->dust->signal.output;
     gateInputs->duration =
@@ -90,23 +90,23 @@ struct cc_sig_DustGate* cc_sig_DustGate_new(
 
 void cc_sig_DustGate_destroy(struct sig_Allocator* allocator,
     struct cc_sig_DustGate* self) {
-    allocator->impl->free(allocator->heap, self->gate->inputs);
+    allocator->impl->free(allocator, self->gate->inputs);
     sig_dsp_TimedGate_destroy(allocator, self->gate);
 
-    allocator->impl->free(allocator->heap,
+    allocator->impl->free(allocator,
         self->densityDurationMultiplier->inputs);
     sig_dsp_Mul_destroy(allocator,
         self->densityDurationMultiplier);
 
-    allocator->impl->free(allocator->heap,
+    allocator->impl->free(allocator,
         self->reciprocalDensity->inputs);
     sig_dsp_Div_destroy(allocator, self->reciprocalDensity);
 
-    allocator->impl->free(allocator->heap, self->dust->inputs);
+    allocator->impl->free(allocator, self->dust->inputs);
     sig_dsp_Dust_destroy(allocator, self->dust);
 
     // We don't call sig_dsp_Signal_destroy
     // because our output is borrowed from self->gate,
     // and it was already freed in TimeGate's destructor.
-    allocator->impl->free(allocator->heap, self);
+    allocator->impl->free(allocator, self);
 }

--- a/hosts/web/examples/oscillator/index.html
+++ b/hosts/web/examples/oscillator/index.html
@@ -15,7 +15,7 @@
 
 			<!-- knobs -->
 			<webaudio-knob id="blueKnob" colors="#fff;#00f;#fff"></webaudio-knob>
-			<webaudio-knob id="redKnob" colors="#fff;#f00;#fff"></webaudio-knob>
+			<webaudio-knob id="redKnob" colors="#fff;#f00;#fff" value="0"></webaudio-knob>
 
 			<!-- jacks midi out, cv, in, out-->
 			<div class="jack"></div>
@@ -37,25 +37,11 @@
             async function initAudioGraph() {
                 let context = new AudioContext();
 
-                let stream = await navigator.mediaDevices.getUserMedia({
-                    audio: {
-                        channelCount: 2,
-                        echoCancellation: false,
-                        noiseSuppression: false,
-                        autoGainControl: false
-                    },
-                    video: false
-                });
-
-                let source = context.createMediaStreamSource(stream);
-
                 await context.audioWorklet.addModule(
                     "../../../../libsignaletic/build/wasm/wasm-oscillator-example.js");
 
                 const signaleticOsc = new AudioWorkletNode(context,
                     "SignaleticOscillator");
-
-                source.connect(signaleticOsc);
                 signaleticOsc.connect(context.destination);
 
                 function bindKnobChange(knobEl, param) {

--- a/hosts/web/examples/oscillator/signaletic-oscillator-worklet.js
+++ b/hosts/web/examples/oscillator/signaletic-oscillator-worklet.js
@@ -84,9 +84,9 @@ class SignaleticOscillator extends AudioWorkletProcessor {
             },
             {
                 name: 'redKnobParam',
-                defaultValue: 0.0,
-                minValue: 0.0,
+                minValue: 0,
                 maxValue: 1.0,
+                defaultValue: 0,
                 automation: 'k-rate'
             }
         ]
@@ -96,26 +96,9 @@ class SignaleticOscillator extends AudioWorkletProcessor {
         // TODO: Signaletic needs value mapping functions
         // like libDaisy, or control values should always
         // mapped using Signals.
-        this.gainValue.parameters.value =
-            parameters.blueKnobParam[0];
-
-        // Inputs may not be connected,
-        // so we have to check before we read them.
-        // TODO: Read inputs at audio rate.
-        // TODO: Treat the two modulation sources (freq and mul)
-        // as separate inputs, rather than as a single
-        // multichannel input.
-        let cvInputs = inputs[0];
-        if (cvInputs.length > 0) {
-            this.ampMod.parameters.value = cvInputs[0][0];
-        }
-
-        if (cvInputs.length > 1) {
-            // Map to MIDI notes between 0..120
-            let freqNote = cvInputs[1][0] * 60.0 + 60.0;
-            this.freqMod.parameters.value = sig.midiToFreq(
-                freqNote);
-        }
+        this.gainValue.parameters.value = parameters.blueKnobParam[0];
+        this.freqMod.parameters.value =
+            parameters.redKnobParam[0] * 1700 + 60;
 
         for (let output of outputs) {
             // Evaluate the Signaletic graph.

--- a/libsignaletic/examples/console/src/print-sine.c
+++ b/libsignaletic/examples/console/src/print-sine.c
@@ -33,7 +33,7 @@ int main(int argc, char *argv[]) {
         .heap = &heap
     };
 
-    allocator.impl->init(allocator.heap);
+    allocator.impl->init(&allocator);
 
     struct sig_dsp_Sine_Inputs inputs = {
         .freq = sig_AudioBlock_newWithValue(&allocator,

--- a/libsignaletic/examples/console/src/print-sine.c
+++ b/libsignaletic/examples/console/src/print-sine.c
@@ -21,13 +21,19 @@ void printBuffer(float* buffer, size_t blockSize) {
 int main(int argc, char *argv[]) {
     struct sig_AudioSettings settings = sig_DEFAULT_AUDIOSETTINGS;
 
-    char heap[HEAP_SIZE];
+    char memory[HEAP_SIZE];
+
+    struct sig_AllocatorHeap heap = {
+        .length = HEAP_SIZE,
+        .memory = memory
+    };
 
     struct sig_Allocator allocator = {
-        .heapSize = HEAP_SIZE,
-        .heap = heap
+        .impl = &sig_TLSFAllocatorImpl,
+        .heap = &heap
     };
-    sig_Allocator_init(&allocator);
+
+    allocator.impl->init(allocator.heap);
 
     struct sig_dsp_Sine_Inputs inputs = {
         .freq = sig_AudioBlock_newWithValue(&allocator,

--- a/libsignaletic/include/libsignaletic.h
+++ b/libsignaletic/include/libsignaletic.h
@@ -308,21 +308,23 @@ struct sig_AllocatorHeap {
     void* memory;
 };
 
+struct sig_Allocator;
+
 /**
  * Type definition for an Allocator init function.
  */
-typedef void (*sig_Allocator_init)(struct sig_AllocatorHeap* heap);
+typedef void (*sig_Allocator_init)(struct sig_Allocator* allocator);
 
 /**
  * Type definition for an Allocator malloc function.
  */
-typedef void* (*sig_Allocator_malloc)(struct sig_AllocatorHeap* heap,
+typedef void* (*sig_Allocator_malloc)(struct sig_Allocator* allocator,
     size_t size);
 
 /**
  * Type definition for an Allocator free function.
  */
-typedef void (*sig_Allocator_free)(struct sig_AllocatorHeap* heap,
+typedef void (*sig_Allocator_free)(struct sig_Allocator* allocator,
     void* obj);
 
 /**
@@ -343,18 +345,19 @@ struct sig_Allocator {
 /**
  * TLSF Allocator init function.
  */
-void sig_TLSFAllocator_init(struct sig_AllocatorHeap* heap);
+void sig_TLSFAllocator_init(struct sig_Allocator* allocator);
 
 /**
  * TLSF Allocator malloc function.
  */
-void* sig_TLSFAllocator_malloc(struct sig_AllocatorHeap* heap,
+void* sig_TLSFAllocator_malloc(struct sig_Allocator* allocator,
     size_t size);
 
 /**
  * TLSF Allocator free function.
  */
-void sig_TLSFAllocator_free(struct sig_AllocatorHeap* heap, void* obj);
+void sig_TLSFAllocator_free(struct sig_Allocator* allocator,
+    void* obj);
 
 /**
  * A realtime-capable memory allocator based on

--- a/libsignaletic/include/libsignaletic.h
+++ b/libsignaletic/include/libsignaletic.h
@@ -360,11 +360,7 @@ void sig_TLSFAllocator_free(struct sig_AllocatorHeap* heap, void* obj);
  * A realtime-capable memory allocator based on
  * Matt Conte's TLSF library.
  */
-static struct sig_AllocatorImpl sig_TLSFAllocatorImpl = {
-    .init = sig_TLSFAllocator_init,
-    .malloc = sig_TLSFAllocator_malloc,
-    .free = sig_TLSFAllocator_free
-};
+extern struct sig_AllocatorImpl sig_TLSFAllocatorImpl;
 
 
 /**

--- a/libsignaletic/src/libsignaletic.c
+++ b/libsignaletic/src/libsignaletic.c
@@ -167,6 +167,12 @@ void sig_TLSFAllocator_free(struct sig_AllocatorHeap* heap,
     tlsf_free(heap->memory, obj);
 }
 
+struct sig_AllocatorImpl sig_TLSFAllocatorImpl = {
+    .init = sig_TLSFAllocator_init,
+    .malloc = sig_TLSFAllocator_malloc,
+    .free = sig_TLSFAllocator_free
+};
+
 
 struct sig_AudioSettings* sig_AudioSettings_new(
     struct sig_Allocator* allocator) {

--- a/libsignaletic/tests/test-libsignaletic.c
+++ b/libsignaletic/tests/test-libsignaletic.c
@@ -9,23 +9,23 @@
 #define HEAP_SIZE 26214400 // 25 MB
 #define BLOCK_SIZE 64
 
-uint8_t memory[HEAP_SIZE];
+uint8_t heapMemory[HEAP_SIZE];
 
 struct sig_AllocatorHeap heap = {
     .length = HEAP_SIZE,
-    .memory = (void*) memory
+    .memory = (void*) heapMemory
 };
 
 struct sig_Allocator allocator = {
-    .heap = &heap,
-    .impl = &sig_TLSFAllocatorImpl
+    .impl = &sig_TLSFAllocatorImpl,
+    .heap = &heap
 };
 
 struct sig_AudioSettings* audioSettings;
 float* silentBlock;
 
 void setUp(void) {
-    sig_TLSFAllocator_init(allocator.heap);
+    allocator.impl->init(allocator.heap);
     audioSettings = sig_AudioSettings_new(&allocator);
     silentBlock = sig_AudioBlock_newWithValue(&allocator,
         audioSettings, 0.0f);
@@ -399,7 +399,8 @@ void test_sig_dsp_Mul(void) {
 
 // TODO: Move into libsignaletic itself
 // as a (semi?) generic input instantiator.
-struct sig_dsp_Sine_Inputs* createSineInputs(struct sig_Allocator* allocator,
+struct sig_dsp_Sine_Inputs* createSineInputs(
+    struct sig_Allocator* allocator,
     struct sig_AudioSettings* audioSettings,
     float freq, float phaseOffset, float mul, float add) {
 
@@ -864,10 +865,10 @@ void test_sig_dsp_TimedGate_bipolar(void) {
 int main(void) {
     UNITY_BEGIN();
 
-    RUN_TEST(test_sig_randf);
     RUN_TEST(test_sig_unipolarToUint12);
     RUN_TEST(test_sig_bipolarToUint12);
     RUN_TEST(test_sig_bipolarToInvUint12);
+    RUN_TEST(test_sig_randf);
     RUN_TEST(test_sig_midiToFreq);
     RUN_TEST(test_sig_fillWithValue);
     RUN_TEST(test_sig_fillWithSilence);

--- a/libsignaletic/tests/util/buffer-test-utils.c
+++ b/libsignaletic/tests/util/buffer-test-utils.c
@@ -5,11 +5,11 @@
 void testAssertBufferContainsValueOnly(struct sig_Allocator* allocator,
     float expectedValue, float* actual,
     size_t len) {
-    float* expectedArray = (float*) sig_Allocator_malloc(allocator,
-        len * sizeof(float));
+    float* expectedArray = (float*) allocator->impl->malloc(
+        allocator->heap, len * sizeof(float));
     sig_fillWithValue(expectedArray, len, expectedValue);
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedArray, actual, len);
-    sig_Allocator_free(allocator, expectedArray);
+    allocator->impl->free(allocator->heap, expectedArray);
 }
 
 void testAssertBuffersNotEqual(float* first, float* second, size_t len) {
@@ -46,7 +46,7 @@ void testAssertBufferIsSilent(struct sig_Allocator* allocator,
 
 void testAssertBufferNotSilent(struct sig_Allocator* allocator,
     float* buffer, size_t len) {
-    float* silence = sig_Allocator_malloc(allocator,
+    float* silence = allocator->impl->malloc(allocator->heap,
         sizeof(float) * len);
     sig_fillWithSilence(silence, len);
     testAssertBuffersNotEqual(silence, buffer, len);
@@ -161,8 +161,8 @@ struct sig_test_BufferPlayer* sig_test_BufferPlayer_new(
     struct sig_AudioSettings* audioSettings,
     struct sig_Buffer* buffer) {
     float_array_ptr output = sig_AudioBlock_new(allocator, audioSettings);
-    struct sig_test_BufferPlayer* self = sig_Allocator_malloc(allocator,
-        sizeof(struct sig_test_BufferPlayer));
+    struct sig_test_BufferPlayer* self = allocator->impl->malloc(
+        allocator->heap, sizeof(struct sig_test_BufferPlayer));
     sig_test_BufferPlayer_init(self, audioSettings, buffer, output);
 
     return self;
@@ -209,8 +209,8 @@ struct sig_test_BufferRecorder* sig_test_BufferRecorder_new(
     struct sig_test_BufferRecorder_Inputs* inputs,
     struct sig_Buffer* buffer) {
     float_array_ptr output = sig_AudioBlock_new(allocator, audioSettings);
-    struct sig_test_BufferRecorder* self = sig_Allocator_malloc(allocator,
-        sizeof(struct sig_test_BufferRecorder));
+    struct sig_test_BufferRecorder* self = allocator->impl->malloc(
+        allocator->heap, sizeof(struct sig_test_BufferRecorder));
     sig_test_BufferRecorder_init(self, audioSettings, inputs, buffer, output);
 
     return self;

--- a/libsignaletic/tests/util/buffer-test-utils.c
+++ b/libsignaletic/tests/util/buffer-test-utils.c
@@ -6,10 +6,10 @@ void testAssertBufferContainsValueOnly(struct sig_Allocator* allocator,
     float expectedValue, float* actual,
     size_t len) {
     float* expectedArray = (float*) allocator->impl->malloc(
-        allocator->heap, len * sizeof(float));
+        allocator, len * sizeof(float));
     sig_fillWithValue(expectedArray, len, expectedValue);
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedArray, actual, len);
-    allocator->impl->free(allocator->heap, expectedArray);
+    allocator->impl->free(allocator, expectedArray);
 }
 
 void testAssertBuffersNotEqual(float* first, float* second, size_t len) {
@@ -46,7 +46,7 @@ void testAssertBufferIsSilent(struct sig_Allocator* allocator,
 
 void testAssertBufferNotSilent(struct sig_Allocator* allocator,
     float* buffer, size_t len) {
-    float* silence = allocator->impl->malloc(allocator->heap,
+    float* silence = allocator->impl->malloc(allocator,
         sizeof(float) * len);
     sig_fillWithSilence(silence, len);
     testAssertBuffersNotEqual(silence, buffer, len);
@@ -162,7 +162,7 @@ struct sig_test_BufferPlayer* sig_test_BufferPlayer_new(
     struct sig_Buffer* buffer) {
     float_array_ptr output = sig_AudioBlock_new(allocator, audioSettings);
     struct sig_test_BufferPlayer* self = allocator->impl->malloc(
-        allocator->heap, sizeof(struct sig_test_BufferPlayer));
+        allocator, sizeof(struct sig_test_BufferPlayer));
     sig_test_BufferPlayer_init(self, audioSettings, buffer, output);
 
     return self;
@@ -210,7 +210,7 @@ struct sig_test_BufferRecorder* sig_test_BufferRecorder_new(
     struct sig_Buffer* buffer) {
     float_array_ptr output = sig_AudioBlock_new(allocator, audioSettings);
     struct sig_test_BufferRecorder* self = allocator->impl->malloc(
-        allocator->heap, sizeof(struct sig_test_BufferRecorder));
+        allocator, sizeof(struct sig_test_BufferRecorder));
     sig_test_BufferRecorder_init(self, audioSettings, inputs, buffer, output);
 
     return self;

--- a/libsignaletic/wasm/bindings/include/libsignaletic-web.h
+++ b/libsignaletic/wasm/bindings/include/libsignaletic-web.h
@@ -1,4 +1,0 @@
-#include <cstddef>;
-
-struct sig_Allocator* sig_Allocator_new(size_t size);
-void sig_Allocator_destroy(struct sig_Allocator* allocator);

--- a/libsignaletic/wasm/bindings/libsignaletic-web-bindings.idl
+++ b/libsignaletic/wasm/bindings/libsignaletic-web-bindings.idl
@@ -108,9 +108,9 @@ interface sig_AllocatorHeap {
 };
 
 interface sig_AllocatorImpl {
-    void init(sig_AllocatorHeap heap);
-    any malloc(sig_AllocatorHeap heap, unsigned long size);
-    void free(sig_AllocatorHeap heap, any obj);
+    void init(sig_Allocator allocator);
+    any malloc(sig_Allocator allocator, unsigned long size);
+    void free(sig_Allocator allocator, any obj);
 };
 
 interface sig_Allocator {

--- a/libsignaletic/wasm/bindings/libsignaletic-web-bindings.idl
+++ b/libsignaletic/wasm/bindings/libsignaletic-web-bindings.idl
@@ -64,7 +64,7 @@ interface Signaletic {
 
     void Signaletic();
 
-    [Value] attribute Signals sig;
+    [Value] attribute Signals dsp;
 
     float fminf(float a, float b);
     float fmaxf(float a, float b);
@@ -83,10 +83,8 @@ interface Signaletic {
     float waveform_reverseSaw(float phase);
     float waveform_triangle(float phase);
 
-    sig_Allocator Allocator_new(unsigned long heapSize);
-    void Allocator_init(sig_Allocator allocator);
-    any Allocator_malloc(sig_Allocator allocator, unsigned long size);
-    void Allocator_free(sig_Allocator allocator, any obj);
+    sig_Allocator TLSFAllocator_new(unsigned long size);
+    void TLSFAllocator_destroy(sig_Allocator allocator);
 
     sig_AudioSettings AudioSettings_new(sig_Allocator allocator);
     void AudioSettings_destroy(sig_Allocator allocator,
@@ -104,9 +102,20 @@ interface Signaletic {
         sig_AudioSettings audioSettings, float value);
 };
 
+interface sig_AllocatorHeap {
+    attribute unsigned long length;
+    attribute any memory;
+};
+
+interface sig_AllocatorImpl {
+    void init(sig_AllocatorHeap heap);
+    any malloc(sig_AllocatorHeap heap, unsigned long size);
+    void free(sig_AllocatorHeap heap, any obj);
+};
+
 interface sig_Allocator {
-    attribute unsigned long heapSize;
-    attribute any heap;
+    attribute sig_AllocatorImpl impl;
+    attribute sig_AllocatorHeap heap;
 };
 
 interface sig_AudioSettings {

--- a/libsignaletic/wasm/bindings/src/libsignaletic-web.cpp
+++ b/libsignaletic/wasm/bindings/src/libsignaletic-web.cpp
@@ -22,7 +22,7 @@ public:
         float_array_ptr left, float_array_ptr right) {
         struct sig_dsp_BinaryOp_Inputs* inputs =
             (struct sig_dsp_BinaryOp_Inputs*)
-                allocator->impl->malloc(allocator->heap,
+                allocator->impl->malloc(allocator,
                     sizeof(sig_dsp_BinaryOp_Inputs));
 
         inputs->left = left;
@@ -33,7 +33,7 @@ public:
 
     void BinaryOp_Inputs_destroy(struct sig_Allocator* allocator,
         struct sig_dsp_BinaryOp_Inputs* self) {
-        allocator->impl->free(allocator->heap, self);
+        allocator->impl->free(allocator, self);
     }
 
     struct sig_dsp_BinaryOp* Add_new(struct sig_Allocator* allocator,
@@ -94,7 +94,7 @@ public:
         float_array_ptr mul, float_array_ptr add) {
         struct sig_dsp_Sine_Inputs* inputs =
             (struct sig_dsp_Sine_Inputs*) allocator->impl->malloc(
-                allocator->heap, sizeof(sig_dsp_Sine_Inputs));
+                allocator, sizeof(sig_dsp_Sine_Inputs));
 
         inputs->freq = freq;
         inputs->phaseOffset = phaseOffset;
@@ -106,7 +106,7 @@ public:
 
     void Sine_Inputs_destroy(struct sig_Allocator* allocator,
         struct sig_dsp_Sine_Inputs* self) {
-        allocator->impl->free(allocator->heap, self);
+        allocator->impl->free(allocator, self);
     }
 
 
@@ -125,7 +125,7 @@ public:
     struct sig_dsp_ClockFreqDetector_Inputs* ClockFreqDetector_Inputs_new(
         struct sig_Allocator* allocator, float_array_ptr source) {
         struct sig_dsp_ClockFreqDetector_Inputs* inputs = (struct sig_dsp_ClockFreqDetector_Inputs*) allocator->impl->malloc(
-            allocator->heap, sizeof(sig_dsp_ClockFreqDetector_Inputs));
+            allocator, sizeof(sig_dsp_ClockFreqDetector_Inputs));
         inputs->source = source;
 
         return inputs;
@@ -134,7 +134,7 @@ public:
     void ClockFreqDetector_Inputs_destroy(
         struct sig_Allocator* allocator,
         struct sig_dsp_ClockFreqDetector_Inputs* self) {
-        allocator->impl->free(allocator->heap, self);
+        allocator->impl->free(allocator, self);
     }
 };
 
@@ -228,7 +228,7 @@ public:
         allocator->impl = &sig_TLSFAllocatorImpl;
         allocator->heap = heap;
 
-        allocator->impl->init(allocator->heap);
+        allocator->impl->init(allocator);
 
         return allocator;
     }


### PR DESCRIPTION
This PR implements the first approach described in #44. Allocators are now containers for two distinct structs: 
1. an ```impl``` that provides pointers to ```malloc```, ```free``` and ```init```
2. a ```heap``` that provides a pointer and size to the memory used by the allocator

I've also refactored the wasm Oscillator example so that it's simpler and less brittle.