### PR TITLE
Resolves gh-57 and gh-60: Refactors inputs and outputs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,6 @@ jobs:
 
       - name: Run unit tests in Node.js
         run: |
-          node --v8-options | grep -B0 -A1 stack-size
           ./run-wasm-tests.sh
 
       - name: run console example in Node.js

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,6 +64,7 @@ jobs:
 
       - name: Run unit tests in Node.js
         run: |
+          node --v8-options | grep -B0 -A1 stack-size
           ./run-wasm-tests.sh
 
       - name: run console example in Node.js

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,13 +60,11 @@ jobs:
 
       - name: Web Assembly build
         run: |
-          cd libsignaletic
-          ./build-libsignaletic-wasm.sh
+          ./cross-build-wasm.sh
 
       - name: Run unit tests in Node.js
         run: |
-          cd libsignaletic
-          meson test -C build/wasm -v
+          ./run-wasm-tests.sh
 
       - name: run console example in Node.js
         run: node ./libsignaletic/build/wasm/libsignaletic-console-example.js
@@ -87,5 +85,4 @@ jobs:
 
       - name: Build Daisy Host and Examples
         run: |
-          cd hosts/daisy
-          ./build-all-daisy.sh
+          ./cross-build-arm.sh

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This project is an early-stage effort to rewrite and redesign the core signal pr
 
 ## Goals
 
-* Provide the signal processing infrastructure to support the development of an interpreted and/or transpiled-to-C minimal "signal expression language."
+* *Multirepresentational*: Signaletic will provide the low-level infrastructure to support both visual patching alongside an interpreted and transpiled-to-C "signal expression language" (and to switch back and forth between representations on the fly).
 * *Live repatching without compilation*: provide a highly mutable audio graph, so that instruments can be dynamically reconfigured while they are running (on platforms where this is appropriate).
-* *Vastly portable*: support deployment on the Web (via Web Assembly), desktop and mobile operating systems (macOS, Windows, Linux, iOS), specialized audio OS-based environments (Bela), and microcontroller-based systems (Daisy).
+* *Vastly portable, "embedded first"*: support deployment on resource-constrained embedded microcontroller-bsaed systems (such as Daisy), browser-based AudioWorklets (via Web Assembly), and desktop and mobile operating systems (macOS, Windows, Linux, iOS).
 * *Fully externalized state*: Provide a means for [fully externalizing all state](http://openresearch.ocadu.ca/id/eprint/2059/1/Clark_sdr_2017_preprint.pdf) via a Nexus-like RESTful API, including:
     * Creating signals
     * Getting signal values/representations
@@ -16,8 +16,9 @@ This project is an early-stage effort to rewrite and redesign the core signal pr
 * Make it easier to compose signal processing algorithms from smaller, self-contained pieces; avoid Flocking's (and SuperCollider's) formal distinction between unit generators and synths.
 * Support variable sample block sizes that can be mixed together in the same graph, including single-sample graphs.
 * Support cyclical graphs, multiplexing/demultiplexing of signals, and multiple channels
-* Provide an architecture that is supportive of multiple processes, including a realtime process that:
-    * Allocates no memory
+* Provide an architecture that is supportive of realtime programming techniques such as:
+    * Static allocation where desired
+    * Constant-time memory allocation where needed
     * Takes no locks
     * Communicates via a lock-free message queue and/or circular buffers
 
@@ -26,6 +27,7 @@ This project is an early-stage effort to rewrite and redesign the core signal pr
 The design of this project is still in flux, and will more fully emerge as I become more familiar with C and the constraints of each of the core environments on which it will run (Web, desktop/mobile, and Daisy, in particular). However, there are a few abstractions that are beginning to crystallize:
 * The core library, consisting of _Signals_ (which can be individual signal generators or compositions of them) and the _Evaluator_ (which draws samples from Signals), will be completely platform-agnostic and must be integrated with a particular audio API. It will be usable 1) directly in C/C++ applications, 2) in Audio Worklets by being compiled to Web Assembly with JavaScript API bindings, 3) within other languages that provide interoperability with the C ABI.
 * A set of _Hosts_ will be developed, which will provide platform-specific logic for connecting to audio input and output devices, encoding/decoding audio files, and mapping hardware-specifc buses (e.g. GPIO, analog pins, or I2S) to Signals.
+
 
 ## Installing Dependencies
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To remove all previous build artifacts and rebuild, run ```rm -r build/native &&
 #### libsignaletic for Web Assembly
 At the root of the Signaletic repository:
 1. Build the Docker image: ```docker build . -t signaletic```
-2. Run the cross-compilation script in Docker: ```docker run --platform=linux/amd64 -v `pwd`:/signaletic signaletic /signaletic/cross-build-all.sh```
+2. Run the cross-compilation script in Docker: ```docker run --platform=linux/amd64 -v `pwd`:/signaletic signaletic /signaletic/cross-build-wasm.sh```
 
 #### Running the Unit Tests
 1. Native: ```meson test -C build/native -v```
@@ -87,7 +87,7 @@ At the root of the Signaletic repository:
 
 ##### Daisy Bluemchen Examples
 1. If you haven't already, build the Docker image ```docker build . -t signaletic```
-2. ```docker run --platform=linux/amd64 -v `pwd`:/signaletic signaletic /signaletic/cross-build-all.sh```
+2. ```docker run --platform=linux/amd64 -v `pwd`:/signaletic signaletic /signaletic/cross-build-arm.sh```
 3. Use the [Daisy Web Programmer](https://electro-smith.github.io/Programmer/) to flash the ```build/signaletic-bluemchen-looper.bin``` binary to the Daisy board, or run ```make program``` while connected to an ST-Link Mini debugger.
 
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ At the root of the Signaletic repository:
 
 #### Running the Unit Tests
 1. Native: ```meson test -C build/native -v```
-2. Node.js wasm: ```node build/wasm/run_tests.js```
+2. Node.js wasm: ```node libsignaletic/build/wasm/run_tests.js```
 3. Browser wasm: Open ```libsignaletic/tests/test-libsignaletic.html``` using VS Code's Live Server plugin or other web server.
 
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ At the root of the Signaletic repository:
 1. Build libsignaletic Web Assembly
 2. Open ```hosts/web/examples/midi-to-freq/index.html``` using VS Code's Live Server plugin or other web server.
 
-##### Daisy Bluemchen Examples
+##### Daisy Examples
 1. If you haven't already, build the Docker image ```docker build . -t signaletic```
 2. ```docker run --platform=linux/amd64 -v `pwd`:/signaletic signaletic /signaletic/cross-build-arm.sh```
 3. Use the [Daisy Web Programmer](https://electro-smith.github.io/Programmer/) to flash the ```build/signaletic-bluemchen-looper.bin``` binary to the Daisy board, or run ```make program``` while connected to an ST-Link Mini debugger.

--- a/cross-build-all.sh
+++ b/cross-build-all.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
 
 # Build Web Assembly version of Signaletic
-cd libsignaletic
-./build-libsignaletic-wasm.sh
+./cross-build-wasm.sh
 
 # Cross-compile non-native host examples
-cd ../hosts/daisy
-./build-all-daisy.sh
+./cross-build-arm.sh

--- a/cross-build-arm.sh
+++ b/cross-build-arm.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Cross-compile non-native host examples
+cd hosts/daisy
+./build-all-daisy.sh

--- a/cross-build-wasm.sh
+++ b/cross-build-wasm.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Build Web Assembly version of Signaletic
+cd libsignaletic
+./build-libsignaletic-wasm.sh
+cd ..

--- a/docs/contributing/developing-a-signal.md
+++ b/docs/contributing/developing-a-signal.md
@@ -71,7 +71,7 @@ A signal's constructor is responsible for allocating memory for the signal's str
 ```c
 struct sig_dsp_${SignalName}* sig_dsp_${SignalName}_new(
     struct sig_Allocator* allocator,
-    struct sig_dsp_SignalContext* context) {
+    struct sig_SignalContext* context) {
     // Allocate memory for the Signal.
     struct sig_dsp_${SignalName}* self = sig_MALLOC(allocator,
         struct sig_dsp_${SignalName});
@@ -93,7 +93,7 @@ The initializer is responsible for assigning values to a signal's struct, settin
 
 ```c
 void sig_dsp_${SignalName}_init(struct sig_dsp_${SignalName}* self,
-    struct sig_dsp_SignalContext* context) {
+    struct sig_SignalContext* context) {
     // Call the base Signal initializer.
     sig_dsp_Signal_init(self, context, *sig_dsp_${SignalName}_generate);
 

--- a/docs/contributing/developing-a-signal.md
+++ b/docs/contributing/developing-a-signal.md
@@ -19,7 +19,7 @@ struct sig_dsp_${SignalName} {
 
     struct sig_dsp_${SignalName}_Parameters parameters;
 
-    struct sig_dsp_Signal_{OutputType} outputs;
+    struct sig_dsp_${OutputType} outputs;
 
     float ${stateName};
 };
@@ -29,14 +29,14 @@ struct sig_dsp_${SignalName} {
 
 In Signaletic, signals can have multiple outputs. For example, oscillators have both a "main" output that contains the oscillator's waveform, as well as an "eoc" output that fires a trigger whenever the oscillator reaches the end of its cycle.
 
-By default, Signaletic defines a series of core output types, which encompass common output topologies. Currently these include:
+By default, Signaletic defines a series of core output types, which cover common output topologies. Currently these include:
  * ```sig_dsp_Signal_SingleMonoOutput```, which provides one mono output called ```main```
  * ```sig_dsp_Oscillator_Outputs```, containing a mono ```main``` and a mono ```eoc`` output
 
 Additional output types for other cases, including multichannel outputs, will be added. Custom outputs are defined as follows:
 
 ```c
-struct sig_dsp_${SignalName}_Output {
+struct sig_dsp_${SignalName}_Outputs {
     float_array_ptr ${outputName};
     float_array_ptr ${otherOutputName};
 };
@@ -80,8 +80,8 @@ struct sig_dsp_${SignalName}* sig_dsp_${SignalName}_new(
     sig_dsp_${SignalName}_init(self, context);
 
     // Allocate output blocks.
-    self->outputs.main = sig_AudioBlock_new(allocator,
-        context->audioSettings);
+    sig_dsp_${OutputType}_newAudioBlocks(allocator, context->audioSettings,
+        &self->outputs);
 
     return self;
 }
@@ -145,6 +145,9 @@ The destructor is responsible for freeing all memory allocated by the signal's c
 ````c
 void sig_dsp_${SignalName}_destroy(struct sig_Allocator* allocator,
     struct sig_dsp_${SignalName}* self) {
+    // Destroy output audio blocks.
+    sig_dsp_${OutputType}_destroyAudioBlocks(allocator, &self->outputs);
+
     // Destroy any memory that was allocated in the Signal's constructor.
 
     // Call the base Signal destructor.

--- a/hosts/daisy/examples/Makefile
+++ b/hosts/daisy/examples/Makefile
@@ -1,0 +1,7 @@
+all:
+	$(MAKE) -C bluemchen
+	$(MAKE) -C dpt
+
+clean:
+	$(MAKE) -C bluemchen clean
+	$(MAKE) -C dpt clean

--- a/hosts/daisy/examples/bluemchen/dusting/src/signaletic-nehcmeulb-dusting.cpp
+++ b/hosts/daisy/examples/bluemchen/dusting/src/signaletic-nehcmeulb-dusting.cpp
@@ -45,19 +45,20 @@ void UpdateOled() {
 
     displayStr.Clear();
     displayStr.Append("Den: ");
-    displayStr.AppendFloat(density->signal.output[0], 3);
+    displayStr.AppendFloat(density->outputs.main[0], 3);
     bluemchen.display.SetCursor(0, 8);
     bluemchen.display.WriteString(displayStr.Cstr(), Font_6x8, true);
 
     displayStr.Clear();
     displayStr.Append("Dur: ");
-    displayStr.AppendFloat(cvDustGate->densityDurationMultiplier->signal.output[0], 3);
+    displayStr.AppendFloat(
+        cvDustGate->densityDurationMultiplier->outputs.main[0], 3);
     bluemchen.display.SetCursor(0, 16);
     bluemchen.display.WriteString(displayStr.Cstr(), Font_6x8, true);
 
     displayStr.Clear();
     displayStr.Append("Clk: ");
-    displayStr.AppendFloat(clockFreq->signal.output[0], 3);
+    displayStr.AppendFloat(clockFreq->outputs.main[0], 3);
     bluemchen.display.SetCursor(0, 24);
     bluemchen.display.WriteString(displayStr.Cstr(), Font_6x8, true);
 
@@ -89,15 +90,19 @@ void AudioCallback(daisy::AudioHandle::InputBuffer in,
     // TODO: Need to implement a Host-provided Input signal.
     clockFreq->inputs.source = (float_array_ptr) in[0];
 
+    // TODO: Add a CV input for controlling density,
+    // which is centred on 0.0 and allows for negative values
+    // so that an incoming clock can be slowed down.
+
     EvaluateSignalGraph();
 
     bluemchen.seed.dac.WriteValue(daisy::DacHandle::Channel::BOTH,
-        sig_unipolarToUint12(cvDustGate->gate->signal.output[0]));
+        sig_unipolarToUint12(cvDustGate->outputs.main[0]));
 
     // Copy mono buffer to stereo output.
     for (size_t i = 0; i < size; i++) {
-        out[0][i] = audioDustGate->gate->signal.output[i];
-        out[1][i] = audioDustGate->dust->signal.output[i];
+        out[0][i] = audioDustGate->outputs.main[i];
+        out[1][i] = audioDustGate->outputs.main[i];
     }
 }
 
@@ -138,24 +143,24 @@ int main(void) {
         &audioSettings, 0.0f);
 
     densityClockSum = sig_dsp_Add_new(&allocator, context);
-    densityClockSum->inputs.left = clockFreq->signal.output;
-    densityClockSum->inputs.right = density->signal.output;
+    densityClockSum->inputs.left = clockFreq->outputs.main;
+    densityClockSum->inputs.right = density->outputs.main;
 
     struct cc_sig_DustGate_Inputs cvInputs = {
-        density: densityClockSum->signal.output,
-        durationPercentage: duration->signal.output
+        density: densityClockSum->outputs.main,
+        durationPercentage: duration->outputs.main
     };
 
     cvDustGate = cc_sig_DustGate_new(&allocator, context, cvInputs);
 
     audioDensityMultiplier = sig_dsp_Mul_new(&allocator, context);
-    audioDensityMultiplier->inputs.left = densityClockSum->signal.output;
+    audioDensityMultiplier->inputs.left = densityClockSum->outputs.main;
     audioDensityMultiplier->inputs.right = sig_AudioBlock_newWithValue(
         &allocator, &audioSettings, 200.0f);
 
     struct cc_sig_DustGate_Inputs audioInputs = {
-        density: audioDensityMultiplier->signal.output,
-        durationPercentage: duration->signal.output
+        density: audioDensityMultiplier->outputs.main,
+        durationPercentage: duration->outputs.main
     };
 
     audioDustGate = cc_sig_DustGate_new(&allocator,

--- a/hosts/daisy/examples/bluemchen/oscillator/src/signaletic-bluemchen-oscillator.cpp
+++ b/hosts/daisy/examples/bluemchen/oscillator/src/signaletic-bluemchen-oscillator.cpp
@@ -113,9 +113,9 @@ int main(void) {
     initControls();
 
     /** Modulators **/
-    freqMod = sig_dsp_Value_new(&allocator, &audioSettings);
+    freqMod = sig_dsp_Value_new(&allocator, context);
     freqMod->parameters.value = 440.0f;
-    ampMod = sig_dsp_Value_new(&allocator, &audioSettings);
+    ampMod = sig_dsp_Value_new(&allocator, context);
     ampMod->parameters.value = 1.0f;
 
     carrier = sig_dsp_Sine_new(&allocator, context);
@@ -125,7 +125,7 @@ int main(void) {
     /** Gain **/
     // Bluemchen's output circuit clips as it approaches full gain,
     // so 0.85 seems to be around the practical maximum value.
-    gainValue = sig_dsp_Value_new(&allocator, &audioSettings);
+    gainValue = sig_dsp_Value_new(&allocator, context);
     gainValue->parameters.value = 0.85f;
 
     gain = sig_dsp_Mul_new(&allocator, context);

--- a/hosts/daisy/examples/bluemchen/oscillator/src/signaletic-bluemchen-oscillator.cpp
+++ b/hosts/daisy/examples/bluemchen/oscillator/src/signaletic-bluemchen-oscillator.cpp
@@ -41,29 +41,27 @@ void UpdateOled() {
 
     displayStr.Clear();
     displayStr.AppendFloat(freqMod->parameters.value, 1);
-    displayStr.Append(" Hz");
     bluemchen.display.SetCursor(0, 8);
+    bluemchen.display.WriteString(displayStr.Cstr(), Font_6x8, true);
+
+    displayStr.Clear();
+    displayStr.Append(" Hz");
+    bluemchen.display.SetCursor(46, 8);
     bluemchen.display.WriteString(displayStr.Cstr(), Font_6x8, true);
 
     bluemchen.display.Update();
 }
 
-void UpdateControls() {
-    freqCoarseKnob.Process();
-    freqFineKnob.Process();
-    vOctCV.Process();
-}
 
 void AudioCallback(daisy::AudioHandle::InputBuffer in,
     daisy::AudioHandle::OutputBuffer out, size_t size) {
-    UpdateControls();
 
     // Bind control values to Signals.
     // TODO: This should be handled by a Host-provided Signal (gh-22).
     // TODO: Replace this with in-graph math.
     // TODO: Add LPF smoothing for the rather glitchy knobs.
-    float vOct = freqCoarseKnob.Value() + vOctCV.Value() +
-        freqFineKnob.Value();
+    float vOct = freqCoarseKnob.Process() + vOctCV.Process() +
+        freqFineKnob.Process();
 
     // TODO: Make a v/Oct Signal
     freqMod->parameters.value = sig_linearToFreq(vOct, sig_FREQ_C4);

--- a/hosts/daisy/examples/dpt/lfos/src/signaletic-dpt-lfos.cpp
+++ b/hosts/daisy/examples/dpt/lfos/src/signaletic-dpt-lfos.cpp
@@ -47,8 +47,6 @@ struct sig_daisy_CVOut* cv1Out;
 
 void AudioCallback(daisy::AudioHandle::InputBuffer in,
     daisy::AudioHandle::OutputBuffer out, size_t size) {
-    patch.ProcessAllControls();
-
     sig_dsp_generateSignals(&signals);
 
     for (size_t i = 0; i < size; i++) {

--- a/hosts/daisy/examples/dpt/lfos/src/signaletic-dpt-lfos.cpp
+++ b/hosts/daisy/examples/dpt/lfos/src/signaletic-dpt-lfos.cpp
@@ -89,31 +89,21 @@ void InitClock(struct sig_AudioSettings* audioSettings,
 }
 
 void InitLFO(struct sig_SignalContext* context, struct sig_Status* status) {
-    struct sig_dsp_BinaryOp_Inputs* lfoClockScaleInputs =
-        sig_dsp_BinaryOp_Inputs_new(&alloc, context);
-    lfoClockScaleInputs->left = clockFreq->signal.output;
-    lfoClockScaleInputs->right = lfoClockScaleValue->signal.output;
-
-    lfoClockScale = sig_dsp_Mul_new(&alloc, context->audioSettings,
-        lfoClockScaleInputs);
+    lfoClockScale = sig_dsp_Mul_new(&alloc, context);
     sig_List_append(&signals, lfoClockScale, status);
+    lfoClockScale->inputs.left = clockFreq->signal.output;
+    lfoClockScale->inputs.right = lfoClockScaleValue->signal.output;
 
-    struct sig_dsp_Oscillator_Inputs* lfoInputs =
-        sig_dsp_Oscillator_Inputs_new(&alloc, context);
-    lfoInputs->freq = lfoClockScale->signal.output;
-    lfoInputs->mul = sig_AudioBlock_newWithValue(&alloc,
+    lfo = sig_dsp_LFTriangle_new(&alloc, context);
+    sig_List_append(&signals, lfo, status);
+    lfo->inputs.freq = lfoClockScale->signal.output;
+    lfo->inputs.mul = sig_AudioBlock_newWithValue(&alloc,
         context->audioSettings, 1.0f);
 
-    lfo = sig_dsp_LFTriangle_new(&alloc, context->audioSettings, lfoInputs);
-    sig_List_append(&signals, lfo, status);
-
-    struct sig_dsp_BinaryOp_Inputs* mulInputs = sig_dsp_BinaryOp_Inputs_new(
-        &alloc, context);
-    mulInputs->left = lfo->signal.output;
-    mulInputs->right = lfoAmpValue->signal.output;
-
-    lfoGain = sig_dsp_Mul_new(&alloc, context->audioSettings, mulInputs);
+    lfoGain = sig_dsp_Mul_new(&alloc, context);
     sig_List_append(&signals, lfoGain, status);
+    lfoGain->inputs.left = lfo->signal.output;
+    lfoGain->inputs.right = lfoAmpValue->signal.output;
 }
 
 void InitCVOutputs(struct sig_AudioSettings* audioSettings,

--- a/hosts/daisy/examples/dpt/lfos/src/signaletic-dpt-lfos.cpp
+++ b/hosts/daisy/examples/dpt/lfos/src/signaletic-dpt-lfos.cpp
@@ -76,33 +76,33 @@ void InitCVInputs(struct sig_SignalContext* context,
 
 void InitClock(struct sig_SignalContext* context, struct sig_Status* status) {
     clockFreq = sig_dsp_ClockFreqDetector_new(&alloc, context);
-    clockFreq->inputs.source = clockInput->signal.output;
+    clockFreq->inputs.source = clockInput->outputs.main;
     sig_List_append(&signals, clockFreq, status);
 }
 
 void InitLFO(struct sig_SignalContext* context, struct sig_Status* status) {
     lfoClockScale = sig_dsp_Mul_new(&alloc, context);
     sig_List_append(&signals, lfoClockScale, status);
-    lfoClockScale->inputs.left = clockFreq->signal.output;
-    lfoClockScale->inputs.right = lfoClockScaleValue->signal.output;
+    lfoClockScale->inputs.left = clockFreq->outputs.main;
+    lfoClockScale->inputs.right = lfoClockScaleValue->outputs.main;
 
     lfo = sig_dsp_LFTriangle_new(&alloc, context);
     sig_List_append(&signals, lfo, status);
-    lfo->inputs.freq = lfoClockScale->signal.output;
+    lfo->inputs.freq = lfoClockScale->outputs.main;
     lfo->inputs.mul = sig_AudioBlock_newWithValue(&alloc,
         context->audioSettings, 1.0f);
 
     lfoGain = sig_dsp_Mul_new(&alloc, context);
     sig_List_append(&signals, lfoGain, status);
-    lfoGain->inputs.left = lfo->signal.output;
-    lfoGain->inputs.right = lfoAmpValue->signal.output;
+    lfoGain->inputs.left = lfo->outputs.main;
+    lfoGain->inputs.right = lfoAmpValue->outputs.main;
 }
 
 void InitCVOutputs(struct sig_SignalContext* context,
     struct sig_Status* status) {
     cv1Out = sig_daisy_CVOut_new(&alloc, context, &host,
         sig_daisy_DPT_CVOUT_1);
-    cv1Out->inputs.source = lfoGain->signal.output;
+    cv1Out->inputs.source = lfoGain->outputs.main;
     sig_List_append(&signals, cv1Out, status);
 
     // TODO: My DPT seems to output -4.67V to 7.96V,

--- a/hosts/daisy/include/cc-signals.h
+++ b/hosts/daisy/include/cc-signals.h
@@ -28,63 +28,53 @@ void cc_sig_DustGate_generate(void* signal) {
 }
 
 void cc_sig_DustGate_init(struct cc_sig_DustGate* self,
-    struct sig_AudioSettings* audioSettings, float_array_ptr output) {
-    sig_dsp_Signal_init(self, audioSettings, output,
-        *cc_sig_DustGate_generate);
+    struct sig_SignalContext* context, float_array_ptr output) {
+    sig_dsp_Signal_init(self, context, output, *cc_sig_DustGate_generate);
 };
 
-struct cc_sig_DustGate* cc_sig_DustGate_new(
-    struct sig_Allocator* allocator, struct sig_SignalContext* context,
-    cc_sig_DustGate_Inputs* inputs) {
+// TODO: There's an asymmetry here with the constructor signature,
+// compared to other signals. The issue is that we need to be able to assign
+// our top-level inputs as inputs to sub-signals. This will need to designed
+// explicitly so that users can compose Signals together, including defining
+// connections between them. It will likely require additional lifecycle hooks
+// for a Signal.
+struct cc_sig_DustGate* cc_sig_DustGate_new(struct sig_Allocator* allocator,
+    struct sig_SignalContext* context, struct cc_sig_DustGate_Inputs inputs) {
+    struct cc_sig_DustGate* self = sig_MALLOC(allocator,
+        struct cc_sig_DustGate);
 
-    struct cc_sig_DustGate* self =
-        (cc_sig_DustGate*) allocator->impl->malloc(allocator,
-        sizeof(struct cc_sig_DustGate));
-
-    struct sig_dsp_Dust_Inputs* dustInputs = (struct sig_dsp_Dust_Inputs*)
-        allocator->impl->malloc(allocator,
-            sizeof(struct sig_dsp_Dust_Inputs));
-    dustInputs->density = inputs->density;
-
-    self->dust = sig_dsp_Dust_new(allocator, context->audioSettings,
-        dustInputs);
+    self->dust = sig_dsp_Dust_new(allocator, context);
+    self->dust->inputs.density = inputs.density;
 
     self->reciprocalDensity = sig_dsp_Div_new(allocator, context);
     self->reciprocalDensity->inputs.left =
         sig_AudioBlock_newWithValue(allocator, context->audioSettings, 1.0f);
-    self->reciprocalDensity->inputs.right = inputs->density;
+    self->reciprocalDensity->inputs.right = inputs.density;
 
     self->densityDurationMultiplier = sig_dsp_Mul_new(allocator, context);
     self->densityDurationMultiplier->inputs.left =
         self->reciprocalDensity->signal.output;
-    self->densityDurationMultiplier->inputs.right = inputs->durationPercentage;
+    self->densityDurationMultiplier->inputs.right =
+        inputs.durationPercentage;
 
-    struct sig_dsp_TimedGate_Inputs* gateInputs =
-        (struct sig_dsp_TimedGate_Inputs*) allocator->impl->malloc(
-            allocator,
-            sizeof(struct sig_dsp_TimedGate_Inputs));
-    gateInputs->trigger =self->dust->signal.output;
-    gateInputs->duration =
+    self->gate = sig_dsp_TimedGate_new(allocator, context);
+    self->gate->inputs.trigger = self->dust->signal.output;
+    self->gate->inputs.duration =
         self->densityDurationMultiplier->signal.output;
 
-    self->gate = sig_dsp_TimedGate_new(allocator,
-        context->audioSettings, gateInputs);
-
-    cc_sig_DustGate_init(self, context->audioSettings, self->gate->signal.output);
+    cc_sig_DustGate_init(self, context, self->gate->signal.output);
 
     return self;
 }
 
 void cc_sig_DustGate_destroy(struct sig_Allocator* allocator,
     struct cc_sig_DustGate* self) {
-    allocator->impl->free(allocator, self->gate->inputs);
     sig_dsp_TimedGate_destroy(allocator, self->gate);
 
     sig_dsp_Mul_destroy(allocator, self->densityDurationMultiplier);
     sig_AudioBlock_destroy(allocator, self->reciprocalDensity->inputs.left);
     sig_dsp_Div_destroy(allocator, self->reciprocalDensity);
 
-    allocator->impl->free(allocator, self->dust->inputs);
     sig_dsp_Dust_destroy(allocator, self->dust);
 
     // We don't call sig_dsp_Signal_destroy

--- a/hosts/daisy/include/cc-signals.h
+++ b/hosts/daisy/include/cc-signals.h
@@ -35,10 +35,11 @@ void cc_sig_DustGate_init(struct cc_sig_DustGate* self,
 
 // TODO: There's an asymmetry here with the constructor signature,
 // compared to other signals. The issue is that we need to be able to assign
-// our top-level inputs as inputs to sub-signals. This will need to designed
-// explicitly so that users can compose Signals together, including defining
-// connections between them. It will likely require additional lifecycle hooks
-// for a Signal.
+// our top-level inputs as inputs to sub-signals.
+// We need a design that will allow users can compose Signals together,
+// including defining connections between them, without requiring custom
+// constructor signatures. This likely require additional lifecycle hooks
+// for a Signal, such as for binding default signal connections.
 struct cc_sig_DustGate* cc_sig_DustGate_new(struct sig_Allocator* allocator,
     struct sig_SignalContext* context, struct cc_sig_DustGate_Inputs inputs) {
     struct cc_sig_DustGate* self = sig_MALLOC(allocator,

--- a/hosts/daisy/include/signaletic-daisy-host.h
+++ b/hosts/daisy/include/signaletic-daisy-host.h
@@ -69,16 +69,12 @@ struct sig_daisy_GateIn {
     int control;
 };
 
-struct sig_daisy_GateIn* sig_daisy_GateIn_new(
-    struct sig_Allocator* allocator,
-    struct sig_AudioSettings* settings,
-    struct sig_daisy_Host* host,
+struct sig_daisy_GateIn* sig_daisy_GateIn_new(struct sig_Allocator* allocator,
+    struct sig_SignalContext* context, struct sig_daisy_Host* host,
     int control);
 void sig_daisy_GateIn_init(struct sig_daisy_GateIn* self,
-    struct sig_AudioSettings* settings,
-    float_array_ptr output,
-    struct sig_daisy_Host* host,
-    int control);
+    struct sig_SignalContext* context, float_array_ptr output,
+    struct sig_daisy_Host* host, int control);
 void sig_daisy_GateIn_generate(void* signal);
 void sig_daisy_GateIn_destroy(struct sig_Allocator* allocator,
     struct sig_daisy_GateIn* self);
@@ -97,16 +93,12 @@ struct sig_daisy_CVIn {
     int control;
 };
 
-struct sig_daisy_CVIn* sig_daisy_CVIn_new(
-    struct sig_Allocator* allocator,
-    struct sig_AudioSettings* settings,
-    struct sig_daisy_Host* host,
+struct sig_daisy_CVIn* sig_daisy_CVIn_new(struct sig_Allocator* allocator,
+    struct sig_SignalContext* context, struct sig_daisy_Host* host,
     int control);
 void sig_daisy_CVIn_init(struct sig_daisy_CVIn* self,
-    struct sig_AudioSettings* settings,
-    float_array_ptr output,
-    struct sig_daisy_Host* host,
-    int control);
+    struct sig_SignalContext* context, float_array_ptr output,
+    struct sig_daisy_Host* host, int control);
 void sig_daisy_CVIn_generate(void* signal);
 void sig_daisy_CVIn_destroy(struct sig_Allocator* allocator,
     struct sig_daisy_CVIn* self);
@@ -119,20 +111,18 @@ struct sig_daisy_CVOut_Inputs {
 struct sig_daisy_CVOut {
     struct sig_dsp_Signal signal;
     struct sig_daisy_CV_Parameters parameters;
-    struct sig_daisy_CVOut_Inputs* inputs;
+    struct sig_daisy_CVOut_Inputs inputs;
     struct sig_daisy_Host* host;
     int control;
 };
 
 struct sig_daisy_CVOut* sig_daisy_CVOut_new(
     struct sig_Allocator* allocator,
-    struct sig_AudioSettings* settings,
-    struct sig_daisy_CVOut_Inputs* inputs,
+    struct sig_SignalContext* context,
     struct sig_daisy_Host* host,
     int control);
 void sig_daisy_CVOut_init(struct sig_daisy_CVOut* self,
-    struct sig_AudioSettings* settings,
-    struct sig_daisy_CVOut_Inputs* inputs,
+    struct sig_SignalContext* context,
     float_array_ptr output,
     struct sig_daisy_Host* host,
     int control);

--- a/hosts/daisy/include/signaletic-daisy-host.h
+++ b/hosts/daisy/include/signaletic-daisy-host.h
@@ -63,9 +63,13 @@ float sig_daisy_DPTHostImpl_getGateValue(
     struct sig_daisy_Host* host, int control);
 
 
+// TODO: Is a different output structure more appropriate here,
+// such as multiple outputs for each gate, or one output with
+// multiple channels?
 struct sig_daisy_GateIn {
     struct sig_dsp_Signal signal;
     struct sig_daisy_Host* host;
+    struct sig_dsp_Signal_SingleMonoOutput outputs;
     int control;
 };
 
@@ -73,8 +77,8 @@ struct sig_daisy_GateIn* sig_daisy_GateIn_new(struct sig_Allocator* allocator,
     struct sig_SignalContext* context, struct sig_daisy_Host* host,
     int control);
 void sig_daisy_GateIn_init(struct sig_daisy_GateIn* self,
-    struct sig_SignalContext* context, float_array_ptr output,
-    struct sig_daisy_Host* host, int control);
+    struct sig_SignalContext* context, struct sig_daisy_Host* host,
+    int control);
 void sig_daisy_GateIn_generate(void* signal);
 void sig_daisy_GateIn_destroy(struct sig_Allocator* allocator,
     struct sig_daisy_GateIn* self);
@@ -86,9 +90,11 @@ struct sig_daisy_CV_Parameters {
 };
 
 // FIXME: Control should at least be a parameter, if not an input.
+// TODO: Is a different output structure more appropriate here?
 struct sig_daisy_CVIn {
     struct sig_dsp_Signal signal;
     struct sig_daisy_CV_Parameters parameters;
+    struct sig_dsp_Signal_SingleMonoOutput outputs;
     struct sig_daisy_Host* host;
     int control;
 };
@@ -97,8 +103,8 @@ struct sig_daisy_CVIn* sig_daisy_CVIn_new(struct sig_Allocator* allocator,
     struct sig_SignalContext* context, struct sig_daisy_Host* host,
     int control);
 void sig_daisy_CVIn_init(struct sig_daisy_CVIn* self,
-    struct sig_SignalContext* context, float_array_ptr output,
-    struct sig_daisy_Host* host, int control);
+    struct sig_SignalContext* context, struct sig_daisy_Host* host,
+    int control);
 void sig_daisy_CVIn_generate(void* signal);
 void sig_daisy_CVIn_destroy(struct sig_Allocator* allocator,
     struct sig_daisy_CVIn* self);
@@ -108,10 +114,14 @@ struct sig_daisy_CVOut_Inputs {
     float_array_ptr source;
 };
 
+// TODO: Should we have a "no output" outputs type,
+// or continue with the idea of passing through the input
+// for chaining?
 struct sig_daisy_CVOut {
     struct sig_dsp_Signal signal;
     struct sig_daisy_CV_Parameters parameters;
     struct sig_daisy_CVOut_Inputs inputs;
+    struct sig_dsp_Signal_SingleMonoOutput outputs;
     struct sig_daisy_Host* host;
     int control;
 };
@@ -122,9 +132,7 @@ struct sig_daisy_CVOut* sig_daisy_CVOut_new(
     struct sig_daisy_Host* host,
     int control);
 void sig_daisy_CVOut_init(struct sig_daisy_CVOut* self,
-    struct sig_SignalContext* context,
-    float_array_ptr output,
-    struct sig_daisy_Host* host,
+    struct sig_SignalContext* context, struct sig_daisy_Host* host,
     int control);
 void sig_daisy_CVOut_generate(void* signal);
 void sig_daisy_CVOut_destroy(struct sig_Allocator* allocator,

--- a/hosts/daisy/include/signaletic-daisy-host.h
+++ b/hosts/daisy/include/signaletic-daisy-host.h
@@ -63,9 +63,6 @@ float sig_daisy_DPTHostImpl_getGateValue(
     struct sig_daisy_Host* host, int control);
 
 
-// TODO: Is a different output structure more appropriate here,
-// such as multiple outputs for each gate, or one output with
-// multiple channels?
 struct sig_daisy_GateIn {
     struct sig_dsp_Signal signal;
     struct sig_daisy_Host* host;
@@ -73,6 +70,8 @@ struct sig_daisy_GateIn {
     int control;
 };
 
+// FIXME: The control value should be specified as a parameter,
+// rather than a special constructor argument.
 struct sig_daisy_GateIn* sig_daisy_GateIn_new(struct sig_Allocator* allocator,
     struct sig_SignalContext* context, struct sig_daisy_Host* host,
     int control);
@@ -90,7 +89,6 @@ struct sig_daisy_CV_Parameters {
 };
 
 // FIXME: Control should at least be a parameter, if not an input.
-// TODO: Is a different output structure more appropriate here?
 struct sig_daisy_CVIn {
     struct sig_dsp_Signal signal;
     struct sig_daisy_CV_Parameters parameters;

--- a/hosts/daisy/src/signaletic-daisy-host.cpp
+++ b/hosts/daisy/src/signaletic-daisy-host.cpp
@@ -73,8 +73,8 @@ struct sig_daisy_GateIn* sig_daisy_GateIn_new(struct sig_Allocator* allocator,
     struct sig_daisy_GateIn* self = sig_MALLOC(allocator,
         struct sig_daisy_GateIn);
     sig_daisy_GateIn_init(self, context, host, control);
-    self->outputs.main = sig_AudioBlock_new(allocator,
-        context->audioSettings);
+    sig_dsp_Signal_SingleMonoOutput_newAudioBlocks(allocator,
+        context->audioSettings, &self->outputs);
 
     return self;
 }
@@ -99,6 +99,8 @@ void sig_daisy_GateIn_generate(void* signal) {
 
 void sig_daisy_GateIn_destroy(struct sig_Allocator* allocator,
     struct sig_daisy_GateIn* self) {
+    sig_dsp_Signal_SingleMonoOutput_destroyAudioBlocks(allocator,
+        &self->outputs);
     sig_dsp_Signal_destroy(allocator, (void*) self);
 }
 
@@ -109,8 +111,8 @@ struct sig_daisy_CVIn* sig_daisy_CVIn_new(struct sig_Allocator* allocator,
     struct sig_daisy_CVIn* self = sig_MALLOC(allocator,
         struct sig_daisy_CVIn);
     sig_daisy_CVIn_init(self, context, host, control);
-    self->outputs.main = sig_AudioBlock_new(allocator,
-        context->audioSettings);
+    sig_dsp_Signal_SingleMonoOutput_newAudioBlocks(allocator,
+        context->audioSettings, &self->outputs);
 
     return self;
 }
@@ -145,6 +147,8 @@ void sig_daisy_CVIn_generate(void* signal) {
 
 void sig_daisy_CVIn_destroy(struct sig_Allocator* allocator,
     struct sig_daisy_CVIn* self) {
+    sig_dsp_Signal_SingleMonoOutput_destroyAudioBlocks(allocator,
+        &self->outputs);
     sig_dsp_Signal_destroy(allocator, (void*) self);
 }
 
@@ -155,8 +159,9 @@ struct sig_daisy_CVOut* sig_daisy_CVOut_new(struct sig_Allocator* allocator,
     struct sig_daisy_CVOut* self = sig_MALLOC(allocator,
         struct sig_daisy_CVOut);
     sig_daisy_CVOut_init(self, context, host, control);
-    self->outputs.main = sig_AudioBlock_new(allocator,
-        context->audioSettings);
+    sig_dsp_Signal_SingleMonoOutput_newAudioBlocks(allocator,
+        context->audioSettings, &self->outputs);
+
     return self;
 }
 
@@ -194,5 +199,7 @@ void sig_daisy_CVOut_generate(void* signal) {
 
 void sig_daisy_CVIn_destroy(struct sig_Allocator* allocator,
     struct sig_daisy_CVOut* self) {
+    sig_dsp_Signal_SingleMonoOutput_destroyAudioBlocks(allocator,
+        &self->outputs);
     sig_dsp_Signal_destroy(allocator, (void*) self);
 }

--- a/hosts/web/examples/oscillator/signaletic-oscillator-worklet.js
+++ b/hosts/web/examples/oscillator/signaletic-oscillator-worklet.js
@@ -34,30 +34,27 @@ class SignaleticOscillator extends AudioWorkletProcessor {
             this.audioSettings);
 
         /** Modulators **/
-        this.freqMod = sig.dsp.Value_new(this.allocator,
-            this.audioSettings);
+        this.freqMod = sig.dsp.Value_new(this.allocator, this.signalContext);
         this.freqMod.parameters.value = 440.0;
-        this.ampMod = sig.dsp.Value_new(this.allocator,
-            this.audioSettings);
+        this.ampMod = sig.dsp.Value_new(this.allocator, this.signalContext);
         this.ampMod.parameters.value = 1.0;
 
-
         /** Carrier **/
-        this.carrier = sig.dsp.Sine_new(this.allocator,
-            this.audioSettings, this.carrierInputs);
-        this.carrier.inputs.freq = this.freqMod.signal.output;
-        this.carrier.inputs.mul = this.ampMod.signal.output;
+        this.carrier = sig.dsp.Sine_new(this.allocator, this.signalContext);
+        this.carrier.inputs.freq = this.freqMod.outputs.main;
+        this.carrier.inputs.mul = this.ampMod.outputs.main;
 
         /** Gain **/
-        this.gainValue = sig.dsp.Value_new(this.allocator, this.audioSettings);
+        this.gainValue = sig.dsp.Value_new(this.allocator,
+            this.signalContext);
         this.gainValue.parameters.value = 0.85;
 
         this.gain = sig.dsp.Mul_new(this.allocator, this.signalContext);
-        this.gain.inputs.left = this.carrier.signal.output;
-        this.gain.inputs.right = this.gainValue.signal.output;
+        this.gain.inputs.left = this.carrier.outputs.main;
+        this.gain.inputs.right = this.gainValue.outputs.main;
 
         this.gainOutput = sig.dereferenceArray(
-            this.gain.signal.output,
+            this.gain.outputs.main,
             this.audioSettings.blockSize,
             "float32");
 

--- a/hosts/web/examples/oscillator/signaletic-oscillator-worklet.js
+++ b/hosts/web/examples/oscillator/signaletic-oscillator-worklet.js
@@ -43,26 +43,18 @@ class SignaleticOscillator extends AudioWorkletProcessor {
 
 
         /** Carrier **/
-        this.carrierInputs = sig.dsp.Oscillator_Inputs_new(
-            this.allocator, this.signalContext);
-        this.carrierInputs.freq = this.freqMod.signal.output;
-        this.carrierInputs.mul = this.ampMod.signal.output;
-
         this.carrier = sig.dsp.Sine_new(this.allocator,
             this.audioSettings, this.carrierInputs);
+        this.carrier.inputs.freq = this.freqMod.signal.output;
+        this.carrier.inputs.mul = this.ampMod.signal.output;
 
         /** Gain **/
-        this.gainValue = sig.dsp.Value_new(this.allocator,
-            this.audioSettings);
+        this.gainValue = sig.dsp.Value_new(this.allocator, this.audioSettings);
         this.gainValue.parameters.value = 0.85;
 
-        this.gainInputs = sig.dsp.BinaryOp_Inputs_new(
-            this.allocator, this.signalContext);
-        this.gainInputs.left = this.carrier.signal.output;
-        this.gainInputs.right = this.gainValue.signal.output;
-
-        this.gain = sig.dsp.Mul_new(this.allocator,
-            this.audioSettings, this.gainInputs);
+        this.gain = sig.dsp.Mul_new(this.allocator, this.signalContext);
+        this.gain.inputs.left = this.carrier.signal.output;
+        this.gain.inputs.right = this.gainValue.signal.output;
 
         this.gainOutput = sig.dereferenceArray(
             this.gain.signal.output,

--- a/libsignaletic/build-libsignaletic-wasm.sh
+++ b/libsignaletic/build-libsignaletic-wasm.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 echo "\nGenerating Web Assembly Bindings"
 mkdir -p build/bindings
 $EMSDK/upstream/emscripten/tools/webidl_binder wasm/bindings/libsignaletic-web-bindings.idl build/bindings/libsignaletic-web-bindings

--- a/libsignaletic/examples/console/src/print-sine.c
+++ b/libsignaletic/examples/console/src/print-sine.c
@@ -4,6 +4,18 @@
 
 #define HEAP_SIZE 1024 * 128
 
+char memory[HEAP_SIZE];
+
+struct sig_AllocatorHeap heap = {
+    .length = HEAP_SIZE,
+    .memory = memory
+};
+
+struct sig_Allocator allocator = {
+    .impl = &sig_TLSFAllocatorImpl,
+    .heap = &heap
+};
+
 void printSample(float sample) {
     printf("%.8f", sample);
 }
@@ -21,28 +33,17 @@ void printBuffer(float* buffer, size_t blockSize) {
 int main(int argc, char *argv[]) {
     struct sig_AudioSettings audioSettings = sig_DEFAULT_AUDIOSETTINGS;
 
-    char memory[HEAP_SIZE];
-
-    struct sig_AllocatorHeap heap = {
-        .length = HEAP_SIZE,
-        .memory = memory
-    };
-
-    struct sig_Allocator allocator = {
-        .impl = &sig_TLSFAllocatorImpl,
-        .heap = &heap
-    };
-
     allocator.impl->init(&allocator);
 
     struct sig_SignalContext* context = sig_SignalContext_new(&allocator,
         &audioSettings);
-
     struct sig_dsp_Oscillator* sine = sig_dsp_Sine_new(&allocator, context);
-    sine->inputs.freq = sig_AudioBlock_newWithValue(&allocator,
-        &audioSettings, 440.0f);
-    sine->inputs.mul = sig_AudioBlock_newWithValue(&allocator,
-        &audioSettings, 1.0f);
+    struct sig_dsp_ConstantValue* freq = sig_dsp_ConstantValue_new(&allocator,
+        context, 440.0f);
+    struct sig_dsp_ConstantValue* amp = sig_dsp_ConstantValue_new(&allocator,
+        context, 1.0f);
+    sine->inputs.freq = freq->outputs.main;
+    sine->inputs.mul = amp->outputs.main;
 
     puts("Sine wave (three blocks): ");
     for (int i = 0; i < 3; i++) {
@@ -50,8 +51,8 @@ int main(int argc, char *argv[]) {
         printBuffer(sine->outputs.main, audioSettings.blockSize);
     }
 
-    allocator.impl->free(&allocator, sine->inputs.freq);
-    allocator.impl->free(&allocator, sine->inputs.mul);
+    sig_dsp_ConstantValue_destroy(&allocator, freq);
+    sig_dsp_ConstantValue_destroy(&allocator, amp);
     sig_dsp_Sine_destroy(&allocator, sine);
     sig_SignalContext_destroy(&allocator, context);
 

--- a/libsignaletic/examples/console/src/print-sine.c
+++ b/libsignaletic/examples/console/src/print-sine.c
@@ -4,16 +4,16 @@
 
 #define HEAP_SIZE 1024 * 128
 
-char memory[HEAP_SIZE];
+char allocatorMemory[HEAP_SIZE];
 
-struct sig_AllocatorHeap heap = {
+struct sig_AllocatorHeap allocatorHeap = {
     .length = HEAP_SIZE,
-    .memory = memory
+    .memory = allocatorMemory
 };
 
 struct sig_Allocator allocator = {
     .impl = &sig_TLSFAllocatorImpl,
-    .heap = &heap
+    .heap = &allocatorHeap
 };
 
 void printSample(float sample) {

--- a/libsignaletic/examples/console/src/print-sine.c
+++ b/libsignaletic/examples/console/src/print-sine.c
@@ -47,7 +47,7 @@ int main(int argc, char *argv[]) {
     puts("Sine wave (three blocks): ");
     for (int i = 0; i < 3; i++) {
         sine->signal.generate(sine);
-        printBuffer(sine->signal.output, audioSettings.blockSize);
+        printBuffer(sine->outputs.main, audioSettings.blockSize);
     }
 
     allocator.impl->free(&allocator, sine->inputs.freq);

--- a/libsignaletic/include/libsignaletic.h
+++ b/libsignaletic/include/libsignaletic.h
@@ -1002,12 +1002,12 @@ struct sig_dsp_Oscillator {
 struct sig_dsp_Oscillator* sig_dsp_Oscillator_new(
     struct sig_Allocator* allocator, struct sig_SignalContext* context,
     sig_dsp_generateFn generate);
-
 void sig_dsp_Oscillator_init(struct sig_dsp_Oscillator* self,
     struct sig_SignalContext* context, sig_dsp_generateFn generate);
-
 void sig_dsp_Oscillator_accumulatePhase(struct sig_dsp_Oscillator* self,
     size_t i);
+void sig_dsp_Oscillator_destroy(struct sig_Allocator* allocator,
+    struct sig_dsp_Oscillator* self);
 
 void sig_dsp_Sine_init(struct sig_dsp_Oscillator* self,
     struct sig_SignalContext* context);

--- a/libsignaletic/include/libsignaletic.h
+++ b/libsignaletic/include/libsignaletic.h
@@ -36,6 +36,8 @@ extern "C" {
 static const float sig_PI = 3.14159265358979323846f;
 static const float sig_TWOPI = 6.283185307179586f;
 static const float sig_RECIP_TWOPI = 0.159154943091895f;
+static const float sig_FREQ_C4 = 261.6256;
+static const float sig_LOG2 = 0.6931471805599453;
 
 enum sig_Result {
     SIG_RESULT_NONE,
@@ -141,6 +143,35 @@ uint16_t sig_bipolarToInvUint12(float sample);
  * @return the frequency in Hz of the note number
  */
 float sig_midiToFreq(float midiNum);
+
+/**
+ * Converts frequencies in hertz to MIDI note numbers.
+ * This algorithm assumes A4 = 440 Hz = MIDI note #69.
+ *
+ * @param frequency the frequency in hertz to convert
+ * @return the MIDI note number corresponding to the frequency
+ */
+float sig_freqToMidi(float frequency);
+
+/**
+ * @brief Converts a floating point value that represents pitch in
+ * a linear scale such as Eurorack-style volts/octave into a frequency in Hz.
+ *
+ * @param value the value to convert
+ * @param middleFreq the frequency at the midpoint (e.g. 261.6256 for middle C4 at 0.0f)
+ * @return float the frequency in hz
+ */
+float sig_linearToFreq(float value, float middleFreq);
+
+/**
+ * @brief Converts a frequency in Hz in to a linear volts per octave-style
+ * floating point value.
+ *
+ * @param value the frequency to convert
+ * @param middleFreq the frequency at the midpoint (e.g. 261.6256 for middle C4 at 0.0f)
+ * @return float the linear value
+ */
+float sig_freqToLinear(float freq, float middleFreq);
 
 /**
  * Type definition for array fill functions.

--- a/libsignaletic/include/libsignaletic.h
+++ b/libsignaletic/include/libsignaletic.h
@@ -626,6 +626,8 @@ float_array_ptr sig_AudioBlock_newWithValue(
     struct sig_AudioSettings* audioSettings,
     float value);
 
+void sig_AudioBlock_destroy(struct sig_Allocator* allocator,
+    float_array_ptr self);
 
 // TODO: Should the signal argument at least be defined
 // as a struct sig_dsp_Signal*, rather than void*?
@@ -695,49 +697,34 @@ struct sig_dsp_BinaryOp_Inputs {
     float_array_ptr right;
 };
 
-struct sig_dsp_BinaryOp_Inputs* sig_dsp_BinaryOp_Inputs_new(
-    struct sig_Allocator* allocator,
-    struct sig_SignalContext* context);
-void sig_dsp_BinaryOp_Inputs_destroy(struct sig_Allocator* allocator,
-    struct sig_dsp_BinaryOp_Inputs* self);
-
 struct sig_dsp_BinaryOp {
     struct sig_dsp_Signal signal;
-    struct sig_dsp_BinaryOp_Inputs* inputs;
+    struct sig_dsp_BinaryOp_Inputs inputs;
 };
 
+void sig_dsp_BinaryOp_init(struct sig_dsp_BinaryOp* self,
+    struct sig_SignalContext* context);
 
 struct sig_dsp_BinaryOp* sig_dsp_Add_new(
-    struct sig_Allocator* allocator,
-    struct sig_AudioSettings* settings,
-    struct sig_dsp_BinaryOp_Inputs* inputs);
+    struct sig_Allocator* allocator, struct sig_SignalContext* context);
 void sig_dsp_Add_init(struct sig_dsp_BinaryOp* self,
-    struct sig_AudioSettings* settings,
-    struct sig_dsp_BinaryOp_Inputs* inputs,
-    float_array_ptr output);
+    struct sig_SignalContext* context, float_array_ptr output);
 void sig_dsp_Add_generate(void* signal);
 void sig_dsp_Add_destroy(struct sig_Allocator* allocator,
     struct sig_dsp_BinaryOp* self);
 
-
-void sig_dsp_Mul_init(struct sig_dsp_BinaryOp* self,
-    struct sig_AudioSettings* settings, struct sig_dsp_BinaryOp_Inputs* inputs, float_array_ptr output);
 struct sig_dsp_BinaryOp* sig_dsp_Mul_new(
-    struct sig_Allocator* allocator,
-    struct sig_AudioSettings* settings,
-    struct sig_dsp_BinaryOp_Inputs* inputs);
+    struct sig_Allocator* allocator, struct sig_SignalContext* context);
+void sig_dsp_Mul_init(struct sig_dsp_BinaryOp* self,
+    struct sig_SignalContext* context, float_array_ptr output);
 void sig_dsp_Mul_generate(void* signal);
-void sig_dsp_Mul_destroy(struct sig_Allocator* allocator, struct sig_dsp_BinaryOp* self);
-
+void sig_dsp_Mul_destroy(struct sig_Allocator* allocator,
+    struct sig_dsp_BinaryOp* self);
 
 struct sig_dsp_BinaryOp* sig_dsp_Div_new(
-    struct sig_Allocator* allocator,
-    struct sig_AudioSettings* settings,
-    struct sig_dsp_BinaryOp_Inputs* inputs);
+    struct sig_Allocator* allocator, struct sig_SignalContext* context);
 void sig_dsp_Div_init(struct sig_dsp_BinaryOp* self,
-    struct sig_AudioSettings* settings,
-    struct sig_dsp_BinaryOp_Inputs* inputs,
-    float_array_ptr output);
+    struct sig_SignalContext* context, float_array_ptr output);
 void sig_dsp_Div_generate(void* signal);
 void sig_dsp_Div_destroy(struct sig_Allocator* allocator,
     struct sig_dsp_BinaryOp* self);
@@ -966,28 +953,19 @@ struct sig_dsp_Oscillator_Inputs {
     float_array_ptr add;
 };
 
-struct sig_dsp_Oscillator_Inputs* sig_dsp_Oscillator_Inputs_new(
-    struct sig_Allocator* allocator, struct sig_SignalContext* context);
-void sig_dsp_Oscillator_Inputs_destroy(
-    struct sig_Allocator* allocator, struct sig_dsp_Oscillator_Inputs* self);
-
-
 struct sig_dsp_Oscillator {
     struct sig_dsp_Signal signal;
-    struct sig_dsp_Oscillator_Inputs* inputs;
+    struct sig_dsp_Oscillator_Inputs inputs;
     float phaseAccumulator;
 };
 
 void sig_dsp_Oscillator_init(struct sig_dsp_Oscillator* self,
-    struct sig_AudioSettings* settings,
-    struct sig_dsp_Oscillator_Inputs* inputs, float_array_ptr output);
+    struct sig_SignalContext* context, float_array_ptr output);
 
 void sig_dsp_Sine_init(struct sig_dsp_Oscillator* self,
-    struct sig_AudioSettings* settings,
-    struct sig_dsp_Oscillator_Inputs* inputs, float_array_ptr output);
+    struct sig_SignalContext* context, float_array_ptr output);
 struct sig_dsp_Oscillator* sig_dsp_Sine_new(struct sig_Allocator* allocator,
-    struct sig_AudioSettings* settings,
-    struct sig_dsp_Oscillator_Inputs* inputs);
+    struct sig_SignalContext* context);
 void sig_dsp_Sine_generate(void* signal);
 void sig_dsp_Sine_destroy(struct sig_Allocator* allocator,
     struct sig_dsp_Oscillator* self);
@@ -995,17 +973,14 @@ void sig_dsp_Sine_destroy(struct sig_Allocator* allocator,
 
 struct sig_dsp_LFTriangle {
     struct sig_dsp_Signal signal;
-    struct sig_dsp_Oscillator_Inputs* inputs;
+    struct sig_dsp_Oscillator_Inputs inputs;
     float phaseAccumulator;
 };
 
 void sig_dsp_LFTriangle_init(struct sig_dsp_Oscillator* self,
-    struct sig_AudioSettings* settings,
-    struct sig_dsp_Oscillator_Inputs* inputs, float_array_ptr output);
+    struct sig_SignalContext* context, float_array_ptr output);
 struct sig_dsp_Oscillator* sig_dsp_LFTriangle_new(
-    struct sig_Allocator* allocator,
-    struct sig_AudioSettings* settings,
-    struct sig_dsp_Oscillator_Inputs* inputs);
+    struct sig_Allocator* allocator, struct sig_SignalContext* context);
 void sig_dsp_LFTriangle_generate(void* signal);
 void sig_dsp_LFTriangle_destroy(struct sig_Allocator* allocator,
     struct sig_dsp_Oscillator* self);

--- a/libsignaletic/include/libsignaletic.h
+++ b/libsignaletic/include/libsignaletic.h
@@ -698,6 +698,13 @@ struct sig_dsp_Signal_SingleMonoOutput {
     float_array_ptr main;
 };
 
+void sig_dsp_Signal_SingleMonoOutput_newAudioBlocks(
+    struct sig_Allocator* allocator,
+    struct sig_AudioSettings* audioSettings,
+    struct sig_dsp_Signal_SingleMonoOutput* outputs);
+void sig_dsp_Signal_SingleMonoOutput_destroyAudioBlocks(
+    struct sig_Allocator* allocator,
+    struct sig_dsp_Signal_SingleMonoOutput* outputs);
 
 struct sig_dsp_Value_Parameters {
     float value;
@@ -992,6 +999,14 @@ struct sig_dsp_Oscillator_Outputs {
     float_array_ptr eoc;
 };
 
+void sig_dsp_Oscillator_Outputs_newAudioBlocks(
+    struct sig_Allocator* allocator,
+    struct sig_AudioSettings* audioSettings,
+    struct sig_dsp_Oscillator_Outputs* outputs);
+void sig_dsp_Oscillator_Outputs_destroyAudioBlocks(
+    struct sig_Allocator* allocator,
+    struct sig_dsp_Oscillator_Outputs* outputs);
+
 struct sig_dsp_Oscillator {
     struct sig_dsp_Signal signal;
     struct sig_dsp_Oscillator_Inputs inputs;
@@ -1008,6 +1023,7 @@ void sig_dsp_Oscillator_accumulatePhase(struct sig_dsp_Oscillator* self,
     size_t i);
 void sig_dsp_Oscillator_destroy(struct sig_Allocator* allocator,
     struct sig_dsp_Oscillator* self);
+
 
 void sig_dsp_Sine_init(struct sig_dsp_Oscillator* self,
     struct sig_SignalContext* context);

--- a/libsignaletic/include/libsignaletic.h
+++ b/libsignaletic/include/libsignaletic.h
@@ -36,8 +36,8 @@ extern "C" {
 static const float sig_PI = 3.14159265358979323846f;
 static const float sig_TWOPI = 6.283185307179586f;
 static const float sig_RECIP_TWOPI = 0.159154943091895f;
-static const float sig_FREQ_C4 = 261.6256;
 static const float sig_LOG2 = 0.6931471805599453;
+static const float sig_FREQ_C4 = 261.6256;
 
 enum sig_Result {
     SIG_RESULT_NONE,
@@ -711,7 +711,7 @@ struct sig_dsp_Value_Parameters {
 };
 
 /**
- * @brief A signal that outputs the value specified by its 'value' parameter.
+ * @brief A signal that outputs a value.
  * This is intended to be used for values that may change periodically as a
  * result of user input.
  */

--- a/libsignaletic/src/libsignaletic.c
+++ b/libsignaletic/src/libsignaletic.c
@@ -573,6 +573,7 @@ void sig_dsp_ConstantValue_init(struct sig_dsp_ConstantValue* self,
 
 void sig_dsp_ConstantValue_destroy(struct sig_Allocator* allocator,
     struct sig_dsp_ConstantValue* self) {
+    sig_AudioBlock_destroy(allocator, self->outputs.main);
     sig_dsp_Signal_destroy(allocator, (void*) self);
 };
 
@@ -980,6 +981,13 @@ struct sig_dsp_Oscillator* sig_dsp_Oscillator_new(
     return self;
 }
 
+void sig_dsp_Oscillator_destroy(struct sig_Allocator* allocator,
+    struct sig_dsp_Oscillator* self) {
+    sig_AudioBlock_destroy(allocator, self->outputs.main);
+    sig_AudioBlock_destroy(allocator, self->outputs.eoc);
+    sig_dsp_Signal_destroy(allocator, (void*) self);
+}
+
 void sig_dsp_Oscillator_init(struct sig_dsp_Oscillator* self,
     struct sig_SignalContext* context, sig_dsp_generateFn generate) {
     sig_dsp_Signal_init(self, context, generate);
@@ -1019,7 +1027,7 @@ struct sig_dsp_Oscillator* sig_dsp_Sine_new(struct sig_Allocator* allocator,
 
 void sig_dsp_Sine_destroy(struct sig_Allocator* allocator,
     struct sig_dsp_Oscillator* self) {
-    sig_dsp_Signal_destroy(allocator, (void*) self);
+    sig_dsp_Oscillator_destroy(allocator, self);
 }
 
 void sig_dsp_Sine_generate(void* signal) {

--- a/libsignaletic/src/libsignaletic.c
+++ b/libsignaletic/src/libsignaletic.c
@@ -491,11 +491,7 @@ void sig_dsp_Signal_init(void* signal, struct sig_SignalContext* context,
 
 void sig_dsp_Signal_noOp(void* signal) {};
 
-// FIXME: We are leaking output block memory for all standard output
-// types here, since they are usually allocated in each Signal's
-// constructor but not destroyed here.
-// TODO: Implement constructors and destructors for the buffers contained
-// in the standard output types.
+// TODO: Should self be defined as a struct_dsp_Signal* in the signature?
 void sig_dsp_Signal_destroy(struct sig_Allocator* allocator,
     void* self) {
     struct sig_dsp_Signal* signal = (struct sig_dsp_Signal*) self;

--- a/libsignaletic/src/libsignaletic.c
+++ b/libsignaletic/src/libsignaletic.c
@@ -479,6 +479,11 @@ void sig_dsp_Signal_init(void* signal, struct sig_SignalContext* context,
 
 void sig_dsp_Signal_noOp(void* signal) {};
 
+// FIXME: We are leaking output block memory for all standard output
+// types here, since they are usually allocated in each Signal's
+// constructor but not destroyed here.
+// TODO: Implement constructors and destructors for the buffers contained
+// in the standard output types.
 void sig_dsp_Signal_destroy(struct sig_Allocator* allocator,
     void* self) {
     struct sig_dsp_Signal* signal = (struct sig_dsp_Signal*) self;

--- a/libsignaletic/src/libsignaletic.c
+++ b/libsignaletic/src/libsignaletic.c
@@ -73,6 +73,18 @@ float sig_midiToFreq(float midiNum) {
     return powf(2, (midiNum - 69.0f) / 12.0f) * 440.0f;
 }
 
+float sig_freqToMidi(float frequency) {
+    return(12.0f * logf(frequency / 440.0f) / sig_LOG2) + 69.0f;
+}
+
+float sig_linearToFreq(float vOct, float middleFreq) {
+    return middleFreq * powf(2, vOct);
+}
+
+float sig_freqToLinear(float freq, float middleFreq) {
+    return (logf(freq / middleFreq) / sig_LOG2);
+}
+
 float sig_randomFill(size_t i, float_array_ptr array) {
     return sig_randf();
 }

--- a/libsignaletic/tests/test-libsignaletic.c
+++ b/libsignaletic/tests/test-libsignaletic.c
@@ -264,9 +264,9 @@ void test_sig_Audio_Block_newWithValue_testForValue(
 }
 
 void test_sig_AudioBlock_newWithValue(void) {
-    char customMemory[262144];
+    char customMemory[32768];
     struct sig_AllocatorHeap customHeap = {
-        .length = 262144,
+        .length = 32768,
         .memory = customMemory
     };
     struct sig_Allocator localAlloc = {

--- a/libsignaletic/tests/test-libsignaletic.c
+++ b/libsignaletic/tests/test-libsignaletic.c
@@ -264,10 +264,10 @@ void test_sig_Audio_Block_newWithValue_testForValue(
 }
 
 void test_sig_AudioBlock_newWithValue(void) {
-    // Note: This "heap" is actually here on the stack,
+    // Note: This "heap" is actually stored here on the stack,
     // so it needs to stay small, or else has to be moved
-    // onto the actual heap. It's here now so that this test
-    // can be a little more self-contained.
+    // onto the program's heap. It's here now so that this test
+    // is more self-contained.
     char customMemory[32768];
     struct sig_AllocatorHeap customHeap = {
         .length = 32768,

--- a/libsignaletic/tests/test-libsignaletic.c
+++ b/libsignaletic/tests/test-libsignaletic.c
@@ -103,12 +103,12 @@ void test_sig_midiToFreq(void) {
 
     // 60 Middle C 261.63
     actual = sig_midiToFreq(60.0f);
-    TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.005, 261.63f, actual,
+    TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.005, sig_FREQ_C4, actual,
         "MIDI C3 should be 261.63 Hz");
 
     // MIDI 0
     actual = sig_midiToFreq(0.0f);
-    TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.005, 8.18f, actual,
+    TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.005, 8.176f, actual,
         "MIDI 0 should be 8.18 Hz");
 
     // Quarter tone
@@ -118,8 +118,80 @@ void test_sig_midiToFreq(void) {
 
     // Negative MIDI note numbers should return viable frequencies.
     actual = sig_midiToFreq(-60.0f);
-    TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.005, 0.255, actual,
+    TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.005, 0.2555, actual,
         "A negative MIDI number should return a negative frequency.");
+}
+
+void test_sig_freqToMidi(void) {
+    // 69 A 440
+    float actual = sig_freqToMidi(440.0f);
+    TEST_ASSERT_FLOAT_WITHIN_MESSAGE(FLOAT_EPSILON, 69.0f, actual,
+        "MIDI A4 should be 440 Hz");
+
+    // 60 Middle C 261.63
+    actual = sig_freqToMidi(sig_FREQ_C4);
+    TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.005f, 60.0f, actual,
+        "MIDI C3 should be 261.63 Hz");
+
+    // MIDI 0
+    actual = sig_freqToMidi(8.176f);
+    TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.005f, 0.0f, actual,
+        "MIDI 0 should be 8.18 Hz");
+
+    // Quarter tone
+    actual = sig_freqToMidi(269.29f);
+    TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.005f, 60.5f, actual,
+        "A quarter tone above C3 should be 269.29 Hz");
+
+    // Negative MIDI note numbers should return viable frequencies.
+    actual = sig_freqToMidi(0.2555f);
+    TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.005f, -60.0f, actual,
+        "A negative MIDI number should return a negative frequency.");
+}
+
+void test_sig_sig_linearToFreq(void) {
+    // 0.0f - 0V - Middle C4 - 261.626
+    float actual = sig_linearToFreq(0.0f, sig_FREQ_C4);
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(sig_FREQ_C4, actual,
+        "0.0f should be middle C 261.626 Hz");
+
+    // 0.75f - 0.75V - A4 440
+    actual = sig_linearToFreq(0.75f, sig_FREQ_C4);
+    TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.001f, 440.0f, actual,
+        "3/4 of a volt should be 440 Hz");
+
+    // 2.5V - F#6 - 1479.98
+    actual = sig_linearToFreq(2.5f, sig_FREQ_C4);
+    TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.005, 1479.98f, actual,
+        "2.5V should be F#5 739.99 Hz");
+
+    // -1.25 - A2 - 110 Hz
+    actual = sig_linearToFreq(-1.25f, sig_FREQ_C4);
+    TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.005, 110.0f, actual,
+        "-1.25V should be A2 110 Hz");
+
+}
+
+void test_sig_sig_freqToLinear(void) {
+    // 0.0f - 0V - Middle C4 - 261.626 - 20Vpp
+    float actual = sig_freqToLinear(sig_FREQ_C4, sig_FREQ_C4);
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(0.0f, actual,
+        "0.0f should be middle C 261.626 Hz");
+
+    // 0.75f - 0.75V - A4 440 - 1Vpp
+    actual = sig_freqToLinear(440.0f, sig_FREQ_C4);
+    TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.001f, 0.75f, actual,
+        "3/4 of a volt should be 440 Hz");
+
+    // 2.5V - F#6 - 1479.98 - 10Vpp
+    actual = sig_freqToLinear(1479.98f, sig_FREQ_C4);
+    TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.005, 2.5f, actual,
+        "2.5V should be F#5 739.99 Hz");
+
+    // -1.25 - A2 - 110 Hz
+    actual = sig_freqToLinear(110.0f, sig_FREQ_C4);
+    TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.005, -1.25f, actual,
+        "-1.25V should be A2 110 Hz");
 }
 
 void test_sig_fillWithValue(void) {
@@ -856,6 +928,9 @@ int main(void) {
     RUN_TEST(test_sig_bipolarToInvUint12);
     RUN_TEST(test_sig_randf);
     RUN_TEST(test_sig_midiToFreq);
+    RUN_TEST(test_sig_freqToMidi);
+    RUN_TEST(test_sig_sig_linearToFreq);
+    RUN_TEST(test_sig_sig_freqToLinear);
     RUN_TEST(test_sig_fillWithValue);
     RUN_TEST(test_sig_fillWithSilence);
     RUN_TEST(test_sig_AudioSettings_new);

--- a/libsignaletic/tests/test-libsignaletic.c
+++ b/libsignaletic/tests/test-libsignaletic.c
@@ -934,9 +934,9 @@ int main(void) {
     RUN_TEST(test_sig_sig_freqToLinear);
     RUN_TEST(test_sig_fillWithValue);
     RUN_TEST(test_sig_fillWithSilence);
-    // RUN_TEST(test_sig_AudioSettings_new);
+    RUN_TEST(test_sig_AudioSettings_new);
     RUN_TEST(test_sig_samplesToSeconds);
-    RUN_TEST(test_sig_AudioBlock_newWithValue);
+    // RUN_TEST(test_sig_AudioBlock_newWithValue);
     RUN_TEST(test_sig_Buffer);
     RUN_TEST(test_sig_BufferView);
     RUN_TEST(test_sig_dsp_Value);

--- a/libsignaletic/tests/test-libsignaletic.c
+++ b/libsignaletic/tests/test-libsignaletic.c
@@ -264,6 +264,10 @@ void test_sig_Audio_Block_newWithValue_testForValue(
 }
 
 void test_sig_AudioBlock_newWithValue(void) {
+    // Note: This "heap" is actually here on the stack,
+    // so it needs to stay small, or else has to be moved
+    // onto the actual heap. It's here now so that this test
+    // can be a little more self-contained.
     char customMemory[32768];
     struct sig_AllocatorHeap customHeap = {
         .length = 32768,

--- a/libsignaletic/tests/test-libsignaletic.c
+++ b/libsignaletic/tests/test-libsignaletic.c
@@ -934,7 +934,7 @@ int main(void) {
     RUN_TEST(test_sig_sig_freqToLinear);
     RUN_TEST(test_sig_fillWithValue);
     RUN_TEST(test_sig_fillWithSilence);
-    RUN_TEST(test_sig_AudioSettings_new);
+    // RUN_TEST(test_sig_AudioSettings_new);
     RUN_TEST(test_sig_samplesToSeconds);
     RUN_TEST(test_sig_AudioBlock_newWithValue);
     RUN_TEST(test_sig_Buffer);

--- a/libsignaletic/tests/test-libsignaletic.c
+++ b/libsignaletic/tests/test-libsignaletic.c
@@ -936,7 +936,7 @@ int main(void) {
     RUN_TEST(test_sig_fillWithSilence);
     RUN_TEST(test_sig_AudioSettings_new);
     RUN_TEST(test_sig_samplesToSeconds);
-    // RUN_TEST(test_sig_AudioBlock_newWithValue);
+    RUN_TEST(test_sig_AudioBlock_newWithValue);
     RUN_TEST(test_sig_Buffer);
     RUN_TEST(test_sig_BufferView);
     RUN_TEST(test_sig_dsp_Value);

--- a/libsignaletic/tests/test-libsignaletic.c
+++ b/libsignaletic/tests/test-libsignaletic.c
@@ -253,12 +253,13 @@ void test_sig_samplesToSeconds() {
 }
 
 void test_sig_Audio_Block_newWithValue_testForValue(
-    struct sig_Allocator* localAlloc, struct sig_AudioSettings* settings,
+    struct sig_Allocator* localAlloc,
+    struct sig_AudioSettings* customSettings,
     float value) {
     float* actual = sig_AudioBlock_newWithValue(localAlloc,
-        settings, value);
+        customSettings, value);
     testAssertBufferContainsValueOnly(&allocator, value, actual,
-        settings->blockSize);
+        customSettings->blockSize);
     sig_AudioBlock_destroy(localAlloc, actual);
 }
 

--- a/libsignaletic/tests/util/buffer-test-utils.c
+++ b/libsignaletic/tests/util/buffer-test-utils.c
@@ -147,23 +147,22 @@ void sig_test_BufferPlayer_generate(void* signal) {
 }
 
 void sig_test_BufferPlayer_init(struct sig_test_BufferPlayer* self,
-    struct sig_AudioSettings* audioSettings,
-    struct sig_Buffer* buffer,
+    struct sig_SignalContext* context, struct sig_Buffer* buffer,
     float_array_ptr output) {
-    sig_dsp_Signal_init(self, audioSettings, output,
-        sig_test_BufferPlayer_generate);
+    sig_dsp_Signal_init(self, context, output,
+        *sig_test_BufferPlayer_generate);
     self->buffer = buffer;
     self->currentSample = 0;
 }
 
 struct sig_test_BufferPlayer* sig_test_BufferPlayer_new(
-    struct sig_Allocator* allocator,
-    struct sig_AudioSettings* audioSettings,
+    struct sig_Allocator* allocator, struct sig_SignalContext* context,
     struct sig_Buffer* buffer) {
-    float_array_ptr output = sig_AudioBlock_new(allocator, audioSettings);
-    struct sig_test_BufferPlayer* self = allocator->impl->malloc(
-        allocator, sizeof(struct sig_test_BufferPlayer));
-    sig_test_BufferPlayer_init(self, audioSettings, buffer, output);
+    float_array_ptr output = sig_AudioBlock_new(allocator,
+        context->audioSettings);
+    struct sig_test_BufferPlayer* self = sig_MALLOC(allocator,
+        struct sig_test_BufferPlayer);
+    sig_test_BufferPlayer_init(self, context, buffer, output);
 
     return self;
 }
@@ -184,7 +183,7 @@ void sig_test_BufferRecorder_generate(void* signal) {
         assert(self->currentSample < self->buffer->length);
 
         FLOAT_ARRAY(self->buffer->samples)[self->currentSample] =
-            FLOAT_ARRAY(self->inputs->source)[i];
+            FLOAT_ARRAY(self->inputs.source)[i];
 
         self->currentSample++;
     }
@@ -192,26 +191,27 @@ void sig_test_BufferRecorder_generate(void* signal) {
 
 void sig_test_BufferRecorder_init(
     struct sig_test_BufferRecorder* self,
-    struct sig_AudioSettings* audioSettings,
-    struct sig_test_BufferRecorder_Inputs* inputs,
+    struct sig_SignalContext* context,
     struct sig_Buffer* buffer,
     float_array_ptr output) {
-    sig_dsp_Signal_init(self, audioSettings, output,
+    sig_dsp_Signal_init(self, context, output,
         sig_test_BufferRecorder_generate);
-    self->inputs = inputs;
+
     self->buffer = buffer;
     self->currentSample = 0;
+
+    self->inputs.source = context->silence->signal.output;
 }
 
 struct sig_test_BufferRecorder* sig_test_BufferRecorder_new(
     struct sig_Allocator* allocator,
-    struct sig_AudioSettings* audioSettings,
-    struct sig_test_BufferRecorder_Inputs* inputs,
+    struct sig_SignalContext* context,
     struct sig_Buffer* buffer) {
-    float_array_ptr output = sig_AudioBlock_new(allocator, audioSettings);
-    struct sig_test_BufferRecorder* self = allocator->impl->malloc(
-        allocator, sizeof(struct sig_test_BufferRecorder));
-    sig_test_BufferRecorder_init(self, audioSettings, inputs, buffer, output);
+    float_array_ptr output = sig_AudioBlock_new(allocator,
+        context->audioSettings);
+    struct sig_test_BufferRecorder* self = sig_MALLOC(allocator,
+        struct sig_test_BufferRecorder);
+    sig_test_BufferRecorder_init(self, context, buffer, output);
 
     return self;
 }

--- a/libsignaletic/tests/util/buffer-test-utils.c
+++ b/libsignaletic/tests/util/buffer-test-utils.c
@@ -3,8 +3,7 @@
 #include <assert.h>
 
 void testAssertBufferContainsValueOnly(struct sig_Allocator* allocator,
-    float expectedValue, float* actual,
-    size_t len) {
+    float expectedValue, float* actual, size_t len) {
     float* expectedArray = (float*) allocator->impl->malloc(
         allocator, len * sizeof(float));
     sig_fillWithValue(expectedArray, len, expectedValue);

--- a/libsignaletic/tests/util/include/buffer-test-utils.h
+++ b/libsignaletic/tests/util/include/buffer-test-utils.h
@@ -19,14 +19,14 @@ void testAssertBufferValuesInRange(float* buffer, size_t len, float min,
 size_t countNonZeroSamples(float* buffer, size_t len);
 
 int16_t countNonZeroSamplesGenerated(struct sig_dsp_Signal* signal,
-    int numRuns);
+    float_array_ptr output, int numRuns);
 
 void testAssertBufferContainsNumZeroSamples(float* buffer,
     size_t len, int16_t expectedNumNonZero);
 
 void testAssertGeneratedSignalContainsApproxNumNonZeroSamples(
-    struct sig_dsp_Signal* signal, int16_t expectedNumNonZero,
-    double errorFactor, int numRuns);
+    struct sig_dsp_Signal* signal, float_array_ptr output,
+    int16_t expectedNumNonZero, double errorFactor, int numRuns);
 
 void evaluateSignals(struct sig_AudioSettings* audioSettings,
     struct sig_dsp_Signal** signals, size_t numSignals, float duration);
@@ -42,6 +42,7 @@ void evaluateSignals(struct sig_AudioSettings* audioSettings,
  */
 struct sig_test_BufferPlayer {
     struct sig_dsp_Signal signal;
+    struct sig_dsp_Signal_SingleMonoOutput outputs;
     struct sig_Buffer* buffer;
     size_t currentSample;
 };
@@ -49,8 +50,7 @@ struct sig_test_BufferPlayer {
 void sig_test_BufferPlayer_generate(void* signal);
 
 void sig_test_BufferPlayer_init(struct sig_test_BufferPlayer* self,
-    struct sig_SignalContext* context, struct sig_Buffer* buffer,
-    float_array_ptr output);
+    struct sig_SignalContext* context, struct sig_Buffer* buffer);
 
 struct sig_test_BufferPlayer* sig_test_BufferPlayer_new(
     struct sig_Allocator* allocator, struct sig_SignalContext* context,
@@ -76,6 +76,7 @@ struct sig_test_BufferRecorder_Inputs {
 struct sig_test_BufferRecorder {
     struct sig_dsp_Signal signal;
     struct sig_test_BufferRecorder_Inputs inputs;
+    struct sig_dsp_Signal_SingleMonoOutput outputs;
     struct sig_Buffer* buffer;
     size_t currentSample;
 };
@@ -85,8 +86,7 @@ void sig_test_BufferRecorder_generate(void* signal);
 void sig_test_BufferRecorder_init(
     struct sig_test_BufferRecorder* self,
     struct sig_SignalContext* context,
-    struct sig_Buffer* buffer,
-    float_array_ptr output);
+    struct sig_Buffer* buffer);
 
 struct sig_test_BufferRecorder* sig_test_BufferRecorder_new(
     struct sig_Allocator* allocator,

--- a/libsignaletic/tests/util/include/buffer-test-utils.h
+++ b/libsignaletic/tests/util/include/buffer-test-utils.h
@@ -49,13 +49,11 @@ struct sig_test_BufferPlayer {
 void sig_test_BufferPlayer_generate(void* signal);
 
 void sig_test_BufferPlayer_init(struct sig_test_BufferPlayer* self,
-    struct sig_AudioSettings* audioSettings,
-    struct sig_Buffer* buffer,
+    struct sig_SignalContext* context, struct sig_Buffer* buffer,
     float_array_ptr output);
 
 struct sig_test_BufferPlayer* sig_test_BufferPlayer_new(
-    struct sig_Allocator* allocator,
-    struct sig_AudioSettings* audioSettings,
+    struct sig_Allocator* allocator, struct sig_SignalContext* context,
     struct sig_Buffer* buffer);
 
 void sig_test_BufferPlayer_destroy(struct sig_Allocator* allocator,
@@ -77,7 +75,7 @@ struct sig_test_BufferRecorder_Inputs {
  */
 struct sig_test_BufferRecorder {
     struct sig_dsp_Signal signal;
-    struct sig_test_BufferRecorder_Inputs* inputs;
+    struct sig_test_BufferRecorder_Inputs inputs;
     struct sig_Buffer* buffer;
     size_t currentSample;
 };
@@ -86,15 +84,13 @@ void sig_test_BufferRecorder_generate(void* signal);
 
 void sig_test_BufferRecorder_init(
     struct sig_test_BufferRecorder* self,
-    struct sig_AudioSettings* audioSettings,
-    struct sig_test_BufferRecorder_Inputs* inputs,
+    struct sig_SignalContext* context,
     struct sig_Buffer* buffer,
     float_array_ptr output);
 
 struct sig_test_BufferRecorder* sig_test_BufferRecorder_new(
     struct sig_Allocator* allocator,
-    struct sig_AudioSettings* audioSettings,
-    struct sig_test_BufferRecorder_Inputs* inputs,
+    struct sig_SignalContext* context,
     struct sig_Buffer* buffer);
 
 void sig_test_BufferRecorder_destroy(struct sig_Allocator* allocator,

--- a/libsignaletic/wasm-cross-compile.txt
+++ b/libsignaletic/wasm-cross-compile.txt
@@ -8,8 +8,8 @@ exe_wrapper = 'node'
 needs_exe_wrapper = true
 
 [built-in options]
-c_link_args = ['-s', 'LINKABLE=1', '-s', 'EXPORTED_RUNTIME_METHODS=ccall', '-s', 'SINGLE_FILE=1', '-s', 'TOTAL_MEMORY=64MB']
-cpp_link_args = ['-s', 'LINKABLE=1', '-s', 'EXPORTED_RUNTIME_METHODS=ccall', '-s', 'SINGLE_FILE=1', '-s', 'TOTAL_MEMORY=64MB']
+c_link_args = ['-s', 'LINKABLE=1', '-s', 'EXPORTED_RUNTIME_METHODS=ccall', '-s', 'SINGLE_FILE=1', '-s', 'TOTAL_MEMORY=32MB']
+cpp_link_args = ['-s', 'LINKABLE=1', '-s', 'EXPORTED_RUNTIME_METHODS=ccall', '-s', 'SINGLE_FILE=1', '-s', 'TOTAL_MEMORY=32MB']
 
 [host_machine]
 system = 'emscripten'

--- a/libsignaletic/wasm-cross-compile.txt
+++ b/libsignaletic/wasm-cross-compile.txt
@@ -8,8 +8,8 @@ exe_wrapper = 'node'
 needs_exe_wrapper = true
 
 [built-in options]
-c_link_args = ['-s', 'LINKABLE=1', '-s', 'EXPORTED_RUNTIME_METHODS=ccall', '-s', 'SINGLE_FILE=1', '-s', 'TOTAL_MEMORY=32MB']
-cpp_link_args = ['-s', 'LINKABLE=1', '-s', 'EXPORTED_RUNTIME_METHODS=ccall', '-s', 'SINGLE_FILE=1', '-s', 'TOTAL_MEMORY=32MB']
+c_link_args = ['-s', 'LINKABLE=1', '-s', 'EXPORTED_RUNTIME_METHODS=ccall', '-s', 'SINGLE_FILE=1', '-s', 'TOTAL_MEMORY=64MB']
+cpp_link_args = ['-s', 'LINKABLE=1', '-s', 'EXPORTED_RUNTIME_METHODS=ccall', '-s', 'SINGLE_FILE=1', '-s', 'TOTAL_MEMORY=64MB']
 
 [host_machine]
 system = 'emscripten'

--- a/libsignaletic/wasm/bindings/libsignaletic-web-bindings.idl
+++ b/libsignaletic/wasm/bindings/libsignaletic-web-bindings.idl
@@ -2,7 +2,7 @@ interface Signals {
     void generateSignals(sig_List signalList);
 
     sig_dsp_Value Value_new(sig_Allocator allocator,
-        sig_AudioSettings audioSettings);
+        sig_SignalContext context);
 
     void Value_destroy(sig_Allocator allocator,
         sig_dsp_Value value);
@@ -38,16 +38,10 @@ interface Signals {
 
 
     sig_dsp_ClockFreqDetector ClockFreqDetector_new(sig_Allocator allocator,
-        sig_AudioSettings audioSettings,
-        sig_dsp_ClockFreqDetector_Inputs inputs);
+        sig_SignalContext context);
 
     void ClockFreqDetector_destroy(sig_Allocator allocator,
         sig_dsp_ClockFreqDetector detector);
-
-    sig_dsp_ClockFreqDetector_Inputs ClockFreqDetector_Inputs_new(sig_Allocator allocator, any source);
-
-    void ClockFreqDetector_Inputs_destroy(sig_Allocator allocator,
-        sig_dsp_ClockFreqDetector_Inputs inputs);
 };
 
 interface Signaletic {
@@ -213,7 +207,7 @@ interface sig_dsp_BinaryOp_Inputs {
 
 interface sig_dsp_ClockFreqDetector {
     [Value] attribute sig_dsp_Signal signal;
-    attribute sig_dsp_ClockFreqDetector_Inputs inputs;
+    [Value] attribute sig_dsp_ClockFreqDetector_Inputs inputs;
 };
 
 interface sig_dsp_ClockFreqDetector_Inputs {

--- a/libsignaletic/wasm/bindings/libsignaletic-web-bindings.idl
+++ b/libsignaletic/wasm/bindings/libsignaletic-web-bindings.idl
@@ -8,47 +8,30 @@ interface Signals {
         sig_dsp_Value value);
 
 
-    sig_dsp_BinaryOp_Inputs BinaryOp_Inputs_new(sig_Allocator allocator,
-        sig_SignalContext context);
-
-    void BinaryOp_Inputs_destroy(sig_Allocator allocator,
-        sig_dsp_BinaryOp_Inputs inputs);
-
     sig_dsp_BinaryOp Mul_new(sig_Allocator allocator,
-        sig_AudioSettings audioSettings,
-        sig_dsp_BinaryOp_Inputs inputs);
+        sig_SignalContext context);
 
     void Mul_destroy(sig_Allocator allocator, sig_dsp_BinaryOp mul);
 
     sig_dsp_BinaryOp Add_new(sig_Allocator allocator,
-        sig_AudioSettings audioSettings,
-        sig_dsp_BinaryOp_Inputs inputs);
+        sig_SignalContext context);
 
     void Add_destroy(sig_Allocator allocator, sig_dsp_BinaryOp add);
 
     sig_dsp_BinaryOp Div_new(sig_Allocator allocator,
-        sig_AudioSettings audioSettings,
-        sig_dsp_BinaryOp_Inputs inputs);
+        sig_SignalContext context);
 
     void Div_destroy(sig_Allocator allocator, sig_dsp_BinaryOp div);
 
 
-    sig_dsp_Oscillator_Inputs Oscillator_Inputs_new(
-        sig_Allocator allocator, sig_SignalContext context);
-
-    void Oscillator_Inputs_destroy(sig_Allocator allocator,
-        sig_dsp_Oscillator_Inputs inputs);
-
     sig_dsp_Oscillator Sine_new(sig_Allocator allocator,
-        sig_AudioSettings audioSettings,
-        sig_dsp_Oscillator_Inputs inputs);
+        sig_SignalContext context);
 
     void Sine_destroy(sig_Allocator allocator,
         sig_dsp_Oscillator sine);
 
     sig_dsp_Oscillator LFTriangle_new(sig_Allocator allocator,
-        sig_AudioSettings audioSettings,
-        sig_dsp_Oscillator_Inputs inputs);
+        sig_SignalContext context);
 
     void LFTriangle_destroy(sig_Allocator allocator,
         sig_dsp_Oscillator triangle);
@@ -131,6 +114,7 @@ interface Signaletic {
         sig_AudioSettings audioSettings);
     any AudioBlock_newWithValue(sig_Allocator allocator,
         sig_AudioSettings audioSettings, float value);
+    void AudioBlock_destroy(sig_Allocator allocator, any audioBlock);
 };
 
 enum sig_Result {
@@ -202,12 +186,6 @@ interface sig_dsp_Value_Parameters {
     attribute float value;
 };
 
-interface sig_dsp_Oscillator {
-    [Value] attribute sig_dsp_Signal signal;
-    attribute sig_dsp_Oscillator_Inputs inputs;
-    attribute float phaseAccumulator;
-};
-
 interface sig_dsp_Oscillator_Inputs {
     attribute any freq;
     attribute any phaseOffset;
@@ -215,10 +193,16 @@ interface sig_dsp_Oscillator_Inputs {
     attribute any add;
 };
 
+interface sig_dsp_Oscillator {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_Oscillator_Inputs inputs;
+    attribute float phaseAccumulator;
+};
+
 
 interface sig_dsp_BinaryOp {
     [Value] attribute sig_dsp_Signal signal;
-    attribute sig_dsp_BinaryOp_Inputs inputs;
+    [Value] attribute sig_dsp_BinaryOp_Inputs inputs;
 };
 
 interface sig_dsp_BinaryOp_Inputs {

--- a/libsignaletic/wasm/bindings/libsignaletic-web-bindings.idl
+++ b/libsignaletic/wasm/bindings/libsignaletic-web-bindings.idl
@@ -156,12 +156,16 @@ interface sig_List {
 
 interface sig_dsp_Signal {
     attribute sig_AudioSettings audioSettings;
-    attribute any output;
     void generate(any signal);
+};
+
+interface sig_dsp_Signal_SingleMonoOutput {
+    attribute any main;
 };
 
 interface sig_dsp_ConstantValue {
     [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
 };
 
 
@@ -170,15 +174,18 @@ interface sig_SignalContext {
     attribute sig_dsp_ConstantValue silence;
 };
 
+
 interface sig_dsp_Value {
     [Value] attribute sig_dsp_Signal signal;
     [Value] attribute sig_dsp_Value_Parameters parameters;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
     attribute float lastSample;
 };
 
 interface sig_dsp_Value_Parameters {
     attribute float value;
 };
+
 
 interface sig_dsp_Oscillator_Inputs {
     attribute any freq;
@@ -187,29 +194,38 @@ interface sig_dsp_Oscillator_Inputs {
     attribute any add;
 };
 
+interface sig_dsp_Oscillator_Outputs {
+    attribute any main;
+    attribute any eoc;
+};
+
 interface sig_dsp_Oscillator {
     [Value] attribute sig_dsp_Signal signal;
     [Value] attribute sig_dsp_Oscillator_Inputs inputs;
+    [Value] attribute sig_dsp_Oscillator_Outputs outputs;
     attribute float phaseAccumulator;
 };
 
-
-interface sig_dsp_BinaryOp {
-    [Value] attribute sig_dsp_Signal signal;
-    [Value] attribute sig_dsp_BinaryOp_Inputs inputs;
-};
 
 interface sig_dsp_BinaryOp_Inputs {
     attribute any left;
     attribute any right;
 };
 
-
-interface sig_dsp_ClockFreqDetector {
+interface sig_dsp_BinaryOp {
     [Value] attribute sig_dsp_Signal signal;
-    [Value] attribute sig_dsp_ClockFreqDetector_Inputs inputs;
+    [Value] attribute sig_dsp_BinaryOp_Inputs inputs;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
 };
+
 
 interface sig_dsp_ClockFreqDetector_Inputs {
     attribute any source;
 };
+
+interface sig_dsp_ClockFreqDetector {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_ClockFreqDetector_Inputs inputs;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+};
+

--- a/libsignaletic/wasm/bindings/src/libsignaletic-web.cpp
+++ b/libsignaletic/wasm/bindings/src/libsignaletic-web.cpp
@@ -11,8 +11,8 @@ public:
 
     struct sig_dsp_Value* Value_new(
         struct sig_Allocator* allocator,
-        struct sig_AudioSettings* audioSettings) {
-        return sig_dsp_Value_new(allocator, audioSettings);
+        struct sig_SignalContext* context) {
+        return sig_dsp_Value_new(allocator, context);
     }
 
     void Value_destroy(struct sig_Allocator* allocator,
@@ -73,29 +73,13 @@ public:
 
     struct sig_dsp_ClockFreqDetector* ClockFreqDetector_new(
         struct sig_Allocator* allocator,
-        struct sig_AudioSettings* audioSettings,
-        struct sig_dsp_ClockFreqDetector_Inputs* inputs) {
-        return sig_dsp_ClockFreqDetector_new(allocator, audioSettings, inputs);
+        struct sig_SignalContext* context) {
+        return sig_dsp_ClockFreqDetector_new(allocator, context);
     }
 
     void ClockFreqDetector_destroy(struct sig_Allocator* allocator,
         struct sig_dsp_ClockFreqDetector* self) {
         return sig_dsp_ClockFreqDetector_destroy(allocator, self);
-    }
-
-    struct sig_dsp_ClockFreqDetector_Inputs* ClockFreqDetector_Inputs_new(
-        struct sig_Allocator* allocator, float_array_ptr source) {
-        struct sig_dsp_ClockFreqDetector_Inputs* inputs = (struct sig_dsp_ClockFreqDetector_Inputs*) allocator->impl->malloc(
-            allocator, sizeof(sig_dsp_ClockFreqDetector_Inputs));
-        inputs->source = source;
-
-        return inputs;
-    }
-
-    void ClockFreqDetector_Inputs_destroy(
-        struct sig_Allocator* allocator,
-        struct sig_dsp_ClockFreqDetector_Inputs* self) {
-        allocator->impl->free(allocator, self);
     }
 };
 

--- a/libsignaletic/wasm/bindings/src/libsignaletic-web.cpp
+++ b/libsignaletic/wasm/bindings/src/libsignaletic-web.cpp
@@ -20,22 +20,9 @@ public:
         return sig_dsp_Value_destroy(allocator, self);
     }
 
-    struct sig_dsp_BinaryOp_Inputs* BinaryOp_Inputs_new(
-        struct sig_Allocator* allocator,
-        struct sig_SignalContext* context) {
-        return sig_dsp_BinaryOp_Inputs_new(allocator, context);
-    }
-
-    void BinaryOp_Inputs_destroy(struct sig_Allocator* allocator,
-        struct sig_dsp_BinaryOp_Inputs* self) {
-        return sig_dsp_BinaryOp_Inputs_destroy(allocator, self);
-    }
-
     struct sig_dsp_BinaryOp* Add_new(struct sig_Allocator* allocator,
-        struct sig_AudioSettings* audioSettings,
-        struct sig_dsp_BinaryOp_Inputs* inputs) {
-        return sig_dsp_Add_new(allocator, audioSettings,
-            inputs);
+        struct sig_SignalContext* context) {
+        return sig_dsp_Add_new(allocator, context);
     }
 
     void Add_destroy(struct sig_Allocator* allocator,
@@ -44,10 +31,8 @@ public:
     }
 
     struct sig_dsp_BinaryOp* Mul_new(struct sig_Allocator* allocator,
-        struct sig_AudioSettings* audioSettings,
-        struct sig_dsp_BinaryOp_Inputs* inputs) {
-        return sig_dsp_Mul_new(allocator, audioSettings,
-            inputs);
+        struct sig_SignalContext* context) {
+        return sig_dsp_Mul_new(allocator, context);
     }
 
     void Mul_destroy(struct sig_Allocator* allocator,
@@ -56,10 +41,8 @@ public:
     }
 
     struct sig_dsp_BinaryOp* Div_new(struct sig_Allocator* allocator,
-        struct sig_AudioSettings* audioSettings,
-        struct sig_dsp_BinaryOp_Inputs* inputs) {
-        return sig_dsp_Div_new(allocator, audioSettings,
-            inputs);
+        struct sig_SignalContext* context) {
+        return sig_dsp_Div_new(allocator, context);
     }
 
     void Div_destroy(struct sig_Allocator* allocator,
@@ -68,10 +51,8 @@ public:
     }
 
     struct sig_dsp_Oscillator* Sine_new(struct sig_Allocator* allocator,
-        struct sig_AudioSettings* audioSettings,
-        struct sig_dsp_Oscillator_Inputs* inputs) {
-        return sig_dsp_Sine_new(allocator, audioSettings,
-            inputs);
+        struct sig_SignalContext* context) {
+        return sig_dsp_Sine_new(allocator, context);
     }
 
     void Sine_destroy(struct sig_Allocator* allocator,
@@ -80,24 +61,13 @@ public:
     }
 
     struct sig_dsp_Oscillator* LFTriangle_new(struct sig_Allocator* allocator,
-        struct sig_AudioSettings* audioSettings,
-        struct sig_dsp_Oscillator_Inputs* inputs) {
-        return sig_dsp_LFTriangle_new(allocator, audioSettings, inputs);
+        struct sig_SignalContext* context) {
+        return sig_dsp_LFTriangle_new(allocator, context);
     }
 
     void LFTriangle_destroy(struct sig_Allocator* allocator,
         struct sig_dsp_Oscillator* self) {
         return sig_dsp_LFTriangle_destroy(allocator, self);
-    }
-
-    struct sig_dsp_Oscillator_Inputs* Oscillator_Inputs_new(
-        struct sig_Allocator* allocator, struct sig_SignalContext* context) {
-        return sig_dsp_Oscillator_Inputs_new(allocator, context);
-    }
-
-    void Oscillator_Inputs_destroy(struct sig_Allocator* allocator,
-        struct sig_dsp_Oscillator_Inputs* self) {
-        sig_dsp_Oscillator_Inputs_destroy(allocator, self);
     }
 
 
@@ -355,6 +325,11 @@ public:
         float value) {
             return sig_AudioBlock_newWithValue(allocator,
                 audioSettings, value);
+    }
+
+    void AudioBlock_destroy(struct sig_Allocator* allocator,
+        float_array_ptr self) {
+        return sig_AudioBlock_destroy(allocator, self);
     }
 
     ~Signaletic() {}

--- a/run-wasm-tests.sh
+++ b/run-wasm-tests.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cd libsignaletic
+
+# Run wasm tests
+meson test -C build/wasm -v

--- a/run-wasm-tests.sh
+++ b/run-wasm-tests.sh
@@ -3,4 +3,4 @@
 cd libsignaletic
 
 # Run wasm tests
-meson test -C build/wasm -v
+node libsignaletic/build/wasm/run_tests.js

--- a/run-wasm-tests.sh
+++ b/run-wasm-tests.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
 
-cd libsignaletic
-
 # Run wasm tests
 node libsignaletic/build/wasm/run_tests.js


### PR DESCRIPTION
This PR includes a number of recent fixes and improvements that were started in the Walthamstow Shed:

1. Adds support for multiple named inputs and outputs - #60
2. Refactors Signals so that the containers of inputs and outputs are direct members rather than pointers - #57
3. Refactors the Bluemchen Oscillator example so that it's simpler and tracks volts per octave
4. Adds functions for converting frequencies to MIDI notes, and to/from linear pitch scales such as volts per octave