### PR TITLE
gh-30: Implements wasm bindings for all of libsignaletic.

### DIFF
--- a/libsignaletic/include/libsignaletic.h
+++ b/libsignaletic/include/libsignaletic.h
@@ -1041,16 +1041,16 @@ float sig_DelayLine_allpassReadAtTime(struct sig_DelayLine* self,
     float source, float tapTime, float sampleRate, float previousSample);
 
 float sig_DelayLine_readAtTimes(struct sig_DelayLine* self, float source,
-    float* tapTimes, float* tapGains, size_t numTaps,
+    float_array_ptr tapTimes, float_array_ptr tapGains, size_t numTaps,
     float sampleRate, float timeScale);
 
 float sig_DelayLine_linearReadAtTimes(struct sig_DelayLine* self,
-    float source, float* tapTimes, float* tapGains, size_t numTaps,
-    float sampleRate, float timeScale);
+    float source, float_array_ptr tapTimes, float_array_ptr tapGains,
+    size_t numTaps, float sampleRate, float timeScale);
 
 float sig_DelayLine_cubicReadAtTimes(struct sig_DelayLine* self,
-    float source, float* tapTimes, float* tapGains, size_t numTaps,
-    float sampleRate, float timeScale);
+    float source, float_array_ptr tapTimes, float_array_ptr tapGains,
+    size_t numTaps, float sampleRate, float timeScale);
 
 void sig_DelayLine_write(struct sig_DelayLine* self, float sample);
 
@@ -1817,12 +1817,9 @@ struct sig_dsp_DustGate {
 
 struct sig_dsp_DustGate* sig_dsp_DustGate_new(struct sig_Allocator* allocator,
     struct sig_SignalContext* context);
-
 void sig_dsp_DustGate_init(struct sig_dsp_DustGate* self,
     struct sig_SignalContext* context);
-
 void sig_dsp_DustGate_generate(void* signal);
-
 void sig_dsp_DustGate_destroy(struct sig_Allocator* allocator,
     struct sig_dsp_DustGate* self);
 
@@ -1981,6 +1978,8 @@ struct sig_dsp_List* sig_dsp_List_new(
     struct sig_Allocator* allocator, struct sig_SignalContext* context);
 void sig_dsp_List_init(struct sig_dsp_List* self,
     struct sig_SignalContext* context);
+float sig_dsp_List_constrain(bool shouldWrap, float index,
+    float lastIndex, float listLength);
 void sig_dsp_List_generate(void* signal);
 void sig_dsp_List_destroy(struct sig_Allocator* allocator,
     struct sig_dsp_List* self);
@@ -2008,8 +2007,6 @@ struct sig_dsp_LinearMap* sig_dsp_LinearMap_new(
     struct sig_Allocator* allocator, struct sig_SignalContext* context);
 void sig_dsp_LinearMap_init(struct sig_dsp_LinearMap* self,
     struct sig_SignalContext* context);
-float sig_dsp_List_constrain(bool shouldWrap, float index,
-    float lastIndex, float listLength);
 void sig_dsp_LinearMap_generate(void* signal);
 void sig_dsp_LinearMap_destroy(struct sig_Allocator* allocator,
     struct sig_dsp_LinearMap* self);
@@ -2419,7 +2416,7 @@ struct sig_dsp_Calibrator_Node {
 };
 
 void sig_dsp_Calibrator_Node_init(struct sig_dsp_Calibrator_Node* nodes,
-    float* targetValues, size_t numNodes);
+    float_array_ptr targetValues, size_t numNodes);
 
 size_t sig_dsp_Calibrator_locateIntervalForValue(float x,
     struct sig_dsp_Calibrator_Node* nodes, size_t numNodes);

--- a/libsignaletic/src/libsignaletic.c
+++ b/libsignaletic/src/libsignaletic.c
@@ -847,22 +847,22 @@ inline float sig_DelayLine_allpassReadAtTime(struct sig_DelayLine* self,
     return tapSum
 
 inline float sig_DelayLine_readAtTimes(struct sig_DelayLine* self,
-    float source, float* tapTimes, float* tapGains, size_t numTaps,
-    float sampleRate, float timeScale) {
+    float source, float_array_ptr tapTimes, float_array_ptr tapGains,
+    size_t numTaps, float sampleRate, float timeScale) {
     sig_DelayLine_readAtTimes_IMPL(self, source, tapTimes,
         tapGains, numTaps, sampleRate, timeScale, sig_DelayLine_readAt);
 }
 
 inline float sig_DelayLine_linearReadAtTimes(struct sig_DelayLine* self,
-    float source, float* tapTimes, float* tapGains, size_t numTaps,
-    float sampleRate, float timeScale) {
+    float source, float_array_ptr tapTimes, float_array_ptr tapGains,
+    size_t numTaps, float sampleRate, float timeScale) {
     sig_DelayLine_readAtTimes_IMPL(self, source, tapTimes,
         tapGains, numTaps, sampleRate, timeScale, sig_DelayLine_linearReadAt);
 }
 
 inline float sig_DelayLine_cubicReadAtTimes(struct sig_DelayLine* self,
-    float source, float* tapTimes, float* tapGains, size_t numTaps,
-    float sampleRate, float timeScale) {
+    float source, float_array_ptr tapTimes, float_array_ptr tapGains,
+    size_t numTaps, float sampleRate, float timeScale) {
     sig_DelayLine_readAtTimes_IMPL(self, source, tapTimes,
         tapGains,numTaps, sampleRate, timeScale, sig_DelayLine_cubicReadAt);
 }
@@ -3553,10 +3553,10 @@ struct sig_dsp_Calibrator* sig_dsp_Calibrator_new(
 
 inline void sig_dsp_Calibrator_Node_init(
     struct sig_dsp_Calibrator_Node* nodes,
-    float* targetValues, size_t numNodes) {
+    float_array_ptr targetValues, size_t numNodes) {
     for (size_t i = 0; i < numNodes; i++) {
         struct sig_dsp_Calibrator_Node* node = &nodes[i];
-        node->target = node->avg = targetValues[i];
+        node->target = node->avg = FLOAT_ARRAY(targetValues)[i];
         node->numSamplesRecorded = 0;
         node->min = INFINITY;
         node->max = -INFINITY;

--- a/libsignaletic/wasm/bindings/libsignaletic-web-bindings.idl
+++ b/libsignaletic/wasm/bindings/libsignaletic-web-bindings.idl
@@ -1,116 +1,3 @@
-interface Signals {
-    void evaluateSignals(sig_List signalList);
-
-    sig_dsp_Value Value_new(sig_Allocator allocator,
-        sig_SignalContext context);
-
-    void Value_destroy(sig_Allocator allocator,
-        sig_dsp_Value value);
-
-
-    sig_dsp_BinaryOp Mul_new(sig_Allocator allocator,
-        sig_SignalContext context);
-
-    void Mul_destroy(sig_Allocator allocator, sig_dsp_BinaryOp mul);
-
-    sig_dsp_BinaryOp Add_new(sig_Allocator allocator,
-        sig_SignalContext context);
-
-    void Add_destroy(sig_Allocator allocator, sig_dsp_BinaryOp add);
-
-    sig_dsp_BinaryOp Div_new(sig_Allocator allocator,
-        sig_SignalContext context);
-
-    void Div_destroy(sig_Allocator allocator, sig_dsp_BinaryOp div);
-
-
-    sig_dsp_Oscillator Sine_new(sig_Allocator allocator,
-        sig_SignalContext context);
-
-    void Sine_destroy(sig_Allocator allocator,
-        sig_dsp_Oscillator sine);
-
-    sig_dsp_Oscillator LFTriangle_new(sig_Allocator allocator,
-        sig_SignalContext context);
-
-    void LFTriangle_destroy(sig_Allocator allocator,
-        sig_dsp_Oscillator triangle);
-
-
-    sig_dsp_ClockDetector ClockDetector_new(sig_Allocator allocator,
-        sig_SignalContext context);
-
-    void ClockDetector_destroy(sig_Allocator allocator,
-        sig_dsp_ClockDetector detector);
-};
-
-interface Signaletic {
-    readonly attribute float PI;
-    readonly attribute float TWOPI;
-
-    void Signaletic();
-
-    [Value] attribute Signals dsp;
-
-    sig_Status Status_new(sig_Allocator allocator);
-    void Status_init(sig_Status status);
-    void Status_reset(sig_Status status);
-    void Status_reportResult(sig_Status status, sig_Result result);
-
-    float fminf(float a, float b);
-    float fmaxf(float a, float b);
-    float clamp(float value, float min, float max);
-    float midiToFreq(float midiNum);
-    void fillWithValue(any array, unsigned long length, float value);
-    void fillWithSilence(any array, unsigned long length);
-    float interpolate_linear(float idx, any table,
-        unsigned long length);
-    float interpolate_cubic(float idx, any table,
-        unsigned long length);
-    float filter_smooth(float current, float previous, float coeff);
-    float waveform_sine(float phase);
-    float waveform_square(float phase);
-    float waveform_saw(float phase);
-    float waveform_reverseSaw(float phase);
-    float waveform_triangle(float phase);
-
-    sig_Allocator TLSFAllocator_new(unsigned long size);
-    void TLSFAllocator_destroy(sig_Allocator allocator);
-
-    sig_List List_new(sig_Allocator allocator,
-        unsigned long capacity);
-    void List_insert(sig_List list, unsigned long index, any item,
-        sig_Status status);
-    void List_append(sig_List list, any item, sig_Status status);
-    any List_pop(sig_List list, sig_Status status);
-    any List_remove(sig_List list, unsigned long index, sig_Status status);
-    void List_destroy(sig_Allocator allocator, sig_List list);
-
-    sig_AudioSettings AudioSettings_new(sig_Allocator allocator);
-    void AudioSettings_destroy(sig_Allocator allocator,
-        sig_AudioSettings audioSettings);
-
-    sig_SignalContext SignalContext_new(sig_Allocator allocator,
-        sig_AudioSettings audioSettings);
-    void SignalContext_destroy(sig_Allocator allocator,
-        sig_SignalContext signalContext);
-
-    sig_Buffer Buffer_new(sig_Allocator allocator,
-        unsigned long length);
-    void Buffer_fill(sig_Buffer buffer, float value);
-    void Buffer_fillWithSilence(sig_Buffer buffer);
-    float Buffer_read(sig_Buffer buffer, float idx);
-    float Buffer_readLinear(sig_Buffer buffer, float idx);
-    float Buffer_readCubic(sig_Buffer buffer, float idx);
-    void Buffer_destroy(sig_Allocator allocator, sig_Buffer buffer);
-
-    any AudioBlock_new(sig_Allocator allocator,
-        sig_AudioSettings audioSettings);
-    any AudioBlock_newWithValue(sig_Allocator allocator,
-        sig_AudioSettings audioSettings, float value);
-    void AudioBlock_destroy(sig_Allocator allocator, any audioBlock);
-};
-
 enum sig_Result {
     "SIG_RESULT_NONE",
     "SIG_RESULT_SUCCESS",
@@ -120,6 +7,12 @@ enum sig_Result {
 
 interface sig_Status {
     attribute sig_Result result;
+};
+
+interface sig_AudioSettings {
+    attribute float sampleRate;
+    attribute unsigned long numChannels;
+    attribute unsigned long blockSize;
 };
 
 interface sig_AllocatorHeap {
@@ -138,10 +31,29 @@ interface sig_Allocator {
     attribute sig_AllocatorHeap heap;
 };
 
-interface sig_AudioSettings {
+interface sig_List {
+    attribute unsigned long capacity;
+    attribute unsigned long length;
+};
+
+interface sig_filter_Smooth {
+    attribute float coeff;
+    attribute float previous;
+};
+
+interface sig_osc_FastLFSine {
     attribute float sampleRate;
-    attribute unsigned long numChannels;
-    attribute unsigned long blockSize;
+    attribute float f;
+    attribute float sinZ;
+    attribute float cosZ;
+};
+
+interface sig_SignalContext {
+    attribute sig_AudioSettings audioSettings;
+    attribute sig_Buffer emptyBuffer;
+    attribute sig_DelayLine oneSampleDelayLine;
+    attribute sig_dsp_ConstantValue silence;
+    attribute sig_dsp_ConstantValue unity;
 };
 
 interface sig_Buffer {
@@ -149,9 +61,9 @@ interface sig_Buffer {
     attribute any samples;
 };
 
-interface sig_List {
-    attribute unsigned long capacity;
-    attribute unsigned long length;
+interface sig_DelayLine {
+    attribute sig_Buffer buffer;
+    attribute unsigned long writeIdx;
 };
 
 interface sig_dsp_Signal {
@@ -163,17 +75,16 @@ interface sig_dsp_Signal_SingleMonoOutput {
     attribute any main;
 };
 
-interface sig_dsp_ConstantValue {
-    [Value] attribute sig_dsp_Signal signal;
-    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+interface sig_dsp_SignalEvaluator {
 };
 
-
-interface sig_SignalContext {
-    attribute sig_AudioSettings audioSettings;
-    attribute sig_dsp_ConstantValue silence;
+interface sig_dsp_SignalListEvaluator {
+    attribute sig_List signalList;
 };
 
+interface sig_dsp_Value_Parameters {
+    attribute float value;
+};
 
 interface sig_dsp_Value {
     [Value] attribute sig_dsp_Signal signal;
@@ -182,10 +93,120 @@ interface sig_dsp_Value {
     attribute float lastSample;
 };
 
-interface sig_dsp_Value_Parameters {
-    attribute float value;
+interface sig_dsp_ConstantValue {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
 };
 
+interface sig_dsp_Abs_Inputs {
+    attribute any source;
+};
+
+interface sig_dsp_Abs {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_Abs_Inputs inputs;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+};
+
+interface sig_dsp_ScaleOffset_Inputs {
+    attribute any source;
+};
+
+interface sig_dsp_ScaleOffset_Parameters {
+    attribute float scale;
+    attribute float offset;
+};
+
+interface sig_dsp_ScaleOffset {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_ScaleOffset_Inputs inputs;
+    [Value] attribute sig_dsp_ScaleOffset_Parameters parameters;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+};
+
+interface sig_dsp_BinaryOp_Inputs {
+    attribute any left;
+    attribute any right;
+};
+
+interface sig_dsp_BinaryOp {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_BinaryOp_Inputs inputs;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+};
+
+interface sig_dsp_Invert_Inputs {
+    attribute any source;
+};
+
+interface sig_dsp_Invert {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_Invert_Inputs inputs;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+};
+
+interface sig_dsp_Accumulate_Inputs {
+    attribute any source;
+    attribute any reset;
+};
+
+interface sig_dsp_Accumulate_Parameters {
+    attribute float accumulatorStart;
+    attribute float wrap;
+    attribute float maxValue;
+};
+
+interface sig_dsp_Accumulate {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_Accumulate_Inputs inputs;
+    [Value] attribute sig_dsp_Accumulate_Parameters parameters;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+    attribute float accumulator;
+    attribute float previousReset;
+};
+
+interface sig_dsp_GatedTimer_Inputs {
+    attribute any gate;
+    attribute any duration;
+    attribute any loop;
+};
+
+interface sig_dsp_GatedTimer {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_GatedTimer_Inputs inputs;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+    attribute unsigned long timer;
+    attribute boolean hasFired;
+    attribute float prevGate;
+};
+
+interface sig_dsp_TimedTriggerCounter_Inputs {
+    attribute any source;
+    attribute any duration;
+    attribute any count;
+};
+
+interface sig_dsp_TimedTriggerCounter {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_TimedTriggerCounter_Inputs inputs;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+    attribute long numTriggers;
+    attribute long timer;
+    attribute boolean isTimerActive;
+    attribute float previousSource;
+};
+
+interface sig_dsp_ToggleGate_Inputs {
+    attribute any trigger;
+};
+
+interface sig_dsp_ToggleGate {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_ToggleGate_Inputs inputs;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+    attribute boolean isGateOpen;
+    attribute float prevTrig;
+};
 
 interface sig_dsp_Oscillator_Inputs {
     attribute any freq;
@@ -206,32 +227,913 @@ interface sig_dsp_Oscillator {
     attribute float phaseAccumulator;
 };
 
-
-interface sig_dsp_BinaryOp_Inputs {
-    attribute any left;
-    attribute any right;
+interface sig_dsp_Smooth_Inputs {
+    attribute any source;
 };
 
-interface sig_dsp_BinaryOp {
+interface sig_dsp_Smooth_Parameters {
+    attribute float time;
+};
+
+interface sig_dsp_Smooth {
     [Value] attribute sig_dsp_Signal signal;
-    [Value] attribute sig_dsp_BinaryOp_Inputs inputs;
+    [Value] attribute sig_dsp_Smooth_Inputs inputs;
+    [Value] attribute sig_dsp_Smooth_Parameters parameters;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+    attribute float a1;
+    attribute float previousTime;
+    attribute float previousSample;
+};
+
+interface sig_dsp_EMA_Inputs {
+    attribute any source;
+};
+
+interface sig_dsp_EMA_Parameters {
+    attribute float alpha;
+};
+
+interface sig_dsp_EMA {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_EMA_Inputs inputs;
+    [Value] attribute sig_dsp_EMA_Parameters parameters;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+    attribute float previousSample;
+};
+
+interface sig_dsp_Tanh_Inputs {
+    attribute any source;
+};
+
+interface sig_dsp_Tanh {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_Tanh_Inputs inputs;
     [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
 };
 
+interface sig_dsp_Looper_Inputs {
+    attribute any source;
+    attribute any start;
+    attribute any end;
+    attribute any speed;
+    attribute any record;
+    attribute any clear;
+};
 
+interface sig_dsp_Looper_Loop {
+    attribute sig_Buffer buffer;
+    attribute unsigned long startIdx;
+    attribute unsigned long length;
+    attribute boolean isEmpty;
+};
 
-interface sig_dsp_ClockDetector_Outputs {
-    attribute any main;
-    attribute any bpm;
+interface sig_dsp_Looper {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_Looper_Inputs inputs;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+    [Value] attribute sig_dsp_Looper_Loop loop;
+    attribute unsigned long loopLastIdx;
+    attribute float playbackPos;
+    attribute float previousRecord;
+    attribute float previousClear;
+};
+
+interface sig_dsp_Dust_Parameters {
+    attribute float bipolar;
+};
+
+interface sig_dsp_Dust_Inputs {
+    attribute any density;
+};
+
+interface sig_dsp_Dust {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_Dust_Inputs inputs;
+    [Value] attribute sig_dsp_Dust_Parameters parameters;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+    attribute float sampleDuration;
+    attribute float previousDensity;
+    attribute float threshold;
+    attribute float scale;
+};
+
+interface sig_dsp_TimedGate_Parameters {
+    attribute float resetOnTrigger;
+    attribute float bipolar;
+};
+
+interface sig_dsp_TimedGate_Inputs {
+    attribute any trigger;
+    attribute any duration;
+};
+
+interface sig_dsp_TimedGate {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_TimedGate_Inputs inputs;
+    [Value] attribute sig_dsp_TimedGate_Parameters parameters;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+    attribute float previousTrigger;
+    attribute float gateValue;
+    attribute float previousDuration;
+    attribute long durationSamps;
+    attribute long samplesRemaining;
+};
+
+interface sig_dsp_DustGate_Inputs {
+    attribute any density;
+    attribute any durationPercentage;
+};
+
+interface sig_dsp_DustGate_Parameters {
+    attribute float bipolar;
+};
+
+interface sig_dsp_DustGate {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_DustGate_Inputs inputs;
+    [Value] attribute sig_dsp_DustGate_Parameters parameters;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+    attribute sig_dsp_Dust dust;
+    attribute sig_dsp_BinaryOp reciprocalDensity;
+    attribute sig_dsp_BinaryOp densityDurationMultiplier;
+    attribute sig_dsp_TimedGate gate;
 };
 
 interface sig_dsp_ClockDetector_Inputs {
     attribute any source;
 };
 
+interface sig_dsp_ClockDetector_Outputs {
+    attribute any main;
+    attribute any bpm;
+};
+
+interface sig_dsp_ClockDetector_Parameters {
+    attribute float threshold;
+};
+
 interface sig_dsp_ClockDetector {
     [Value] attribute sig_dsp_Signal signal;
     [Value] attribute sig_dsp_ClockDetector_Inputs inputs;
+    [Value] attribute sig_dsp_ClockDetector_Parameters parameters;
     [Value] attribute sig_dsp_ClockDetector_Outputs outputs;
+    attribute float previousTrigger;
+    attribute boolean isRisingEdge;
+    attribute octet numPulsesDetected;
+    attribute unsigned long samplesSinceLastPulse;
+    attribute float clockFreq;
+    attribute unsigned long pulseDurSamples;
 };
 
+interface sig_dsp_LinearToFreq_Inputs {
+    attribute any source;
+};
+
+interface sig_dsp_LinearToFreq_Parameters {
+    attribute float middleFreq;
+};
+
+interface sig_dsp_LinearToFreq {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_LinearToFreq_Inputs inputs;
+    [Value] attribute sig_dsp_LinearToFreq_Parameters parameters;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+};
+
+interface sig_dsp_Branch_Inputs {
+    attribute any off;
+    attribute any on;
+    attribute any condition;
+};
+
+interface sig_dsp_Branch {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_Branch_Inputs inputs;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+};
+
+interface sig_dsp_List_Outputs {
+    attribute any main;
+    attribute any index;
+    attribute any length;
+};
+
+interface sig_dsp_List_Parameters {
+    attribute float wrap;
+    attribute float normalizeIndex;
+    attribute float interpolate;
+};
+
+interface sig_dsp_List_Inputs {
+    attribute any index;
+};
+
+interface sig_dsp_List {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_List_Inputs inputs;
+    [Value] attribute sig_dsp_List_Parameters parameters;
+    [Value] attribute sig_dsp_List_Outputs outputs;
+    attribute sig_Buffer list;
+};
+
+interface sig_dsp_LinearMap_Inputs {
+    attribute any source;
+};
+
+interface sig_dsp_LinearMap_Parameters {
+    attribute float fromMin;
+    attribute float fromMax;
+    attribute float toMin;
+    attribute float toMax;
+};
+
+interface sig_dsp_LinearMap {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_LinearMap_Inputs inputs;
+    [Value] attribute sig_dsp_LinearMap_Parameters parameters;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+};
+
+interface sig_dsp_TwoOpFM_Inputs {
+    attribute any frequency;
+    attribute any index;
+    attribute any ratio;
+    attribute any phaseOffset;
+};
+
+interface sig_dsp_TwoOpFM_Outputs {
+    attribute any main;
+    attribute any modulator;
+};
+
+interface sig_dsp_TwoOpFM {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_TwoOpFM_Inputs inputs;
+    [Value] attribute sig_dsp_TwoOpFM_Outputs outputs;
+    attribute sig_dsp_BinaryOp modulatorFrequency;
+    attribute sig_dsp_BinaryOp carrierPhaseOffset;
+    attribute sig_dsp_Oscillator modulator;
+    attribute sig_dsp_Oscillator carrier;
+};
+
+enum sig_dsp_OnePole_Mode {
+    "sig_dsp_OnePole_Mode_HIGH_PASS",
+    "sig_dsp_OnePole_Mode_LOW_PASS",
+    "sig_dsp_OnePole_Mode_NOT_SPECIFIED"
+};
+
+interface sig_dsp_OnePole_Parameters {
+    attribute sig_dsp_OnePole_Mode mode;
+};
+
+interface sig_dsp_OnePole_Inputs {
+    attribute any source;
+    attribute any frequency;
+};
+
+interface sig_dsp_OnePole {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_OnePole_Inputs inputs;
+    [Value] attribute sig_dsp_OnePole_Parameters parameters;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+    attribute float b0;
+    attribute float a1;
+    attribute sig_dsp_OnePole_Mode previousMode;
+    attribute float previousFrequency;
+    attribute float previousSample;
+};
+
+interface sig_dsp_FourPoleFilter_Inputs {
+    attribute any source;
+    attribute any frequency;
+    attribute any resonance;
+    attribute any inputGain;
+    attribute any pole1Gain;
+    attribute any pole2Gain;
+    attribute any pole3Gain;
+    attribute any pole4Gain;
+};
+
+interface sig_dsp_FourPoleFilter_Outputs {
+    attribute any main;
+    attribute any twoPole;
+    attribute any fourPole;
+};
+
+interface sig_dsp_Bob {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_FourPoleFilter_Inputs inputs;
+    [Value] attribute sig_dsp_FourPoleFilter_Outputs outputs;
+    attribute float[] state;
+    attribute float[] deriv1;
+    attribute float[] deriv2;
+    attribute float[] deriv3;
+    attribute float[] deriv4;
+    attribute float[] tempState;
+    attribute float saturation;
+    attribute float saturationInv;
+    attribute octet oversample;
+    attribute float stepSize;
+};
+
+interface sig_dsp_Ladder_Parameters {
+    attribute float passbandGain;
+};
+
+interface sig_dsp_Ladder {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_FourPoleFilter_Inputs inputs;
+    [Value] attribute sig_dsp_Ladder_Parameters parameters;
+    [Value] attribute sig_dsp_FourPoleFilter_Outputs outputs;
+    attribute octet interpolation;
+    attribute float interpolationRecip;
+    attribute float alpha;
+    attribute float[] beta;
+    attribute float[] z0;
+    attribute float[] z1;
+    attribute float k;
+    attribute float fBase;
+    attribute float qAdjust;
+    attribute float prevFrequency;
+    attribute float prevInput;
+};
+
+interface sig_dsp_TiltEQ_Inputs {
+    attribute any source;
+    attribute any frequency;
+    attribute any gain;
+};
+
+interface sig_dsp_TiltEQ {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_TiltEQ_Inputs inputs;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+    attribute float sr3;
+    attribute float lpOut;
+};
+
+interface sig_dsp_Delay_Inputs {
+    attribute any source;
+    attribute any delayTime;
+};
+
+interface sig_dsp_Delay {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_Delay_Inputs inputs;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+    attribute sig_DelayLine delayLine;
+};
+
+interface sig_dsp_DelayWrite_Inputs {
+    attribute any source;
+};
+
+interface sig_dsp_DelayWrite {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_DelayWrite_Inputs inputs;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+    attribute sig_DelayLine delayLine;
+};
+
+interface sig_dsp_Comb_Inputs {
+    attribute any source;
+    attribute any delayTime;
+    attribute any feedbackGain;
+    attribute any lpfCoefficient;
+};
+
+interface sig_dsp_Comb {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_Comb_Inputs inputs;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+    attribute sig_DelayLine delayLine;
+    attribute float previousSample;
+};
+
+interface sig_dsp_Allpass_Inputs {
+    attribute any source;
+    attribute any delayTime;
+    attribute any g;
+};
+
+interface sig_dsp_Allpass {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_Allpass_Inputs inputs;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+    attribute sig_DelayLine delayLine;
+};
+
+interface sig_dsp_Chorus_Inputs {
+    attribute any source;
+    attribute any delayTime;
+    attribute any speed;
+    attribute any width;
+    attribute any feedbackGain;
+    attribute any feedforwardGain;
+    attribute any blend;
+};
+
+interface sig_dsp_Chorus_Outputs {
+    attribute any main;
+    attribute any modulator;
+};
+
+interface sig_dsp_Chorus {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_Chorus_Inputs inputs;
+    [Value] attribute sig_dsp_Chorus_Outputs outputs;
+    attribute sig_DelayLine delayLine;
+    [Value] attribute sig_osc_FastLFSine modulator;
+    attribute float previousFixedOutput;
+    attribute float previousModulatedOutput;
+};
+
+interface sig_dsp_LinearXFade_Inputs {
+    attribute any left;
+    attribute any right;
+    attribute any mix;
+};
+
+interface sig_dsp_LinearXFade {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_LinearXFade_Inputs inputs;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+};
+
+interface sig_dsp_Calibrator_Inputs {
+    attribute any source;
+    attribute any gate;
+};
+
+interface sig_dsp_Calibrator_Node {
+    attribute float target;
+    attribute unsigned long numSamplesRecorded;
+    attribute float min;
+    attribute float max;
+    attribute float sum;
+    attribute float avg;
+    attribute float diff;
+};
+
+interface sig_dsp_Calibrator {
+    [Value] attribute sig_dsp_Signal signal;
+    [Value] attribute sig_dsp_Calibrator_Inputs inputs;
+    [Value] attribute sig_dsp_Signal_SingleMonoOutput outputs;
+    [Value] attribute sig_dsp_Calibrator_Node[] nodes;
+    attribute float previousGate;
+    attribute unsigned long stage;
+};
+
+interface Signals {
+    void Signal_SingleMonoOutput_newAudioBlocks(sig_Allocator allocator,
+        sig_AudioSettings audioSettings,
+        sig_dsp_Signal_SingleMonoOutput outputs);
+    void Signal_SingleMonoOutput_destroyAudioBlocks(sig_Allocator allocator,
+        sig_dsp_Signal_SingleMonoOutput outputs);
+
+    void evaluateSignals(sig_List signalList);
+
+    sig_dsp_SignalListEvaluator SignalListEvaluator_new(
+        sig_Allocator allocator, sig_List signalList);
+    void SignalListEvaluator_init(sig_dsp_SignalListEvaluator evaluator,
+        sig_List signalList);
+    void SignalListEvaluator_evaluate(sig_dsp_SignalEvaluator evaluator);
+    void SignalListEvaluator_destroy(sig_Allocator allocator, sig_dsp_SignalListEvaluator evaluator);
+
+    sig_dsp_Value Value_new(sig_Allocator allocator, sig_SignalContext context);
+    void Value_init(sig_dsp_Value signal, sig_SignalContext context);
+    void Value_generate(any signal);
+    void Value_destroy(sig_Allocator allocator, sig_dsp_Value signal);
+
+    sig_dsp_ConstantValue ConstantValue_new(sig_Allocator allocator,
+        sig_SignalContext context, float value);
+    void ConstantValue_init(sig_dsp_ConstantValue signal,
+        sig_SignalContext context, float value);
+    void ConstantValue_destroy(sig_Allocator allocator,
+        sig_dsp_ConstantValue signal);
+
+    sig_dsp_Abs Abs_new(sig_Allocator allocator, sig_SignalContext context);
+    void Abs_init(sig_dsp_Abs signal, sig_SignalContext context);
+    void Abs_generate(any signal);
+    void Abs_destroy(sig_Allocator allocator, sig_dsp_Abs signal);
+
+    sig_dsp_ScaleOffset ScaleOffset_new(sig_Allocator allocator, sig_SignalContext context);
+    void ScaleOffset_init(sig_dsp_ScaleOffset signal, sig_SignalContext context);
+    void ScaleOffset_generate(any signal);
+    void ScaleOffset_destroy(sig_Allocator allocator, sig_dsp_ScaleOffset signal);
+
+    sig_dsp_BinaryOp Add_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void Add_init(sig_dsp_BinaryOp signal, sig_SignalContext context);
+    void Add_generate(any signal);
+    void Add_destroy(sig_Allocator allocator, sig_dsp_BinaryOp signal);
+
+    sig_dsp_BinaryOp Sub_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void Sub_init(sig_dsp_BinaryOp signal, sig_SignalContext context);
+    void Sub_generate(any signal);
+    void Sub_destroy(sig_Allocator allocator, sig_dsp_BinaryOp signal);
+
+    sig_dsp_BinaryOp Mul_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void Mul_init(sig_dsp_BinaryOp signal, sig_SignalContext context);
+    void Mul_generate(any signal);
+    void Mul_destroy(sig_Allocator allocator, sig_dsp_BinaryOp signal);
+
+    sig_dsp_BinaryOp Div_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void Div_init(sig_dsp_BinaryOp signal, sig_SignalContext context);
+    void Div_generate(any signal);
+    void Div_destroy(sig_Allocator allocator, sig_dsp_BinaryOp signal);
+
+    sig_dsp_Invert Invert_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void Invert_init(sig_dsp_Invert signal, sig_SignalContext context);
+    void Invert_generate(any signal);
+    void Invert_destroy(sig_Allocator allocator, sig_dsp_Invert signal);
+
+    sig_dsp_Accumulate Accumulate_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void Accumulate_init(sig_dsp_Accumulate signal, sig_SignalContext context);
+    void Accumulate_generate(any signal);
+    void Accumulate_destroy(sig_Allocator allocator, sig_dsp_Accumulate signal);
+
+    sig_dsp_GatedTimer GatedTimer_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void GatedTimer_init(sig_dsp_GatedTimer signal, sig_SignalContext context);
+    void GatedTimer_generate(any signal);
+    void GatedTimer_destroy(sig_Allocator allocator, sig_dsp_GatedTimer signal);
+
+    sig_dsp_TimedTriggerCounter TimedTriggerCounter_new(
+        sig_Allocator allocator, sig_SignalContext context);
+    void TimedTriggerCounter_init(sig_dsp_TimedTriggerCounter signal,
+        sig_SignalContext context);
+    void TimedTriggerCounter_generate(any signal);
+    void TimedTriggerCounter_destroy(sig_Allocator allocator,
+        sig_dsp_TimedTriggerCounter signal);
+
+    sig_dsp_ToggleGate ToggleGate_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void ToggleGate_init(sig_dsp_ToggleGate signal, sig_SignalContext context);
+    void ToggleGate_generate(any signal);
+    void ToggleGate_destroy(sig_Allocator allocator, sig_dsp_ToggleGate signal);
+
+    void Oscillator_Outputs_newAudioBlocks(sig_Allocator allocator,
+        sig_AudioSettings audioSettings, sig_dsp_Oscillator_Outputs outputs);
+    void Oscillator_Outputs_destroyAudioBlocks(sig_Allocator allocator,
+        sig_dsp_Oscillator_Outputs outputs);
+
+    float Oscillator_eoc(float phase);
+    float Oscillator_wrapPhase(float phase);
+    void Oscillator_accumulatePhase(sig_dsp_Oscillator signal, unsigned long i);
+    void Oscillator_destroy(sig_Allocator allocator, sig_dsp_Oscillator signal);
+
+    void Sine_init(sig_dsp_Oscillator signal, sig_SignalContext context);
+    sig_dsp_Oscillator Sine_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void Sine_generate(any signal);
+    void Sine_destroy(sig_Allocator allocator, sig_dsp_Oscillator signal);
+
+    void LFTriangle_init(sig_dsp_Oscillator signal, sig_SignalContext context);
+    sig_dsp_Oscillator LFTriangle_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void LFTriangle_generate(any signal);
+    void LFTriangle_destroy(sig_Allocator allocator, sig_dsp_Oscillator signal);
+
+    void Smooth_init(sig_dsp_Smooth signal, sig_SignalContext context);
+    sig_dsp_Smooth Smooth_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void Smooth_generate(any signal);
+    void Smooth_destroy(sig_Allocator allocator, sig_dsp_Smooth signal);
+
+    void EMA_init(sig_dsp_EMA signal, sig_SignalContext context);
+    sig_dsp_EMA EMA_new(sig_Allocator allocator, sig_SignalContext context);
+    void EMA_generate(any signal);
+    void EMA_destroy(sig_Allocator allocator, sig_dsp_EMA signal);
+
+    void Tanh_init(sig_dsp_Tanh signal, sig_SignalContext context);
+    sig_dsp_Tanh Tanh_new(sig_Allocator allocator, sig_SignalContext context);
+    void Tanh_generate(any signal);
+    void Tanh_destroy(sig_Allocator allocator, sig_dsp_Tanh signal);
+
+    void Looper_init(sig_dsp_Looper signal, sig_SignalContext context);
+    sig_dsp_Looper Looper_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void Looper_setBuffer(sig_dsp_Looper signal, sig_Buffer buffer);
+    void Looper_generate(any signal);
+    void Looper_destroy(sig_Allocator allocator, sig_dsp_Looper signal);
+
+    void Dust_init(sig_dsp_Dust signal, sig_SignalContext context);
+    sig_dsp_Dust Dust_new(sig_Allocator allocator, sig_SignalContext context);
+    void Dust_generate(any signal);
+    void Dust_destroy(sig_Allocator allocator, sig_dsp_Dust signal);
+
+    void TimedGate_init(sig_dsp_TimedGate signal, sig_SignalContext context);
+    sig_dsp_TimedGate TimedGate_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void TimedGate_generate(any signal);
+    void TimedGate_destroy(sig_Allocator allocator, sig_dsp_TimedGate signal);
+
+    sig_dsp_DustGate DustGate_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void DustGate_init(sig_dsp_DustGate signal, sig_SignalContext context);
+    void DustGate_generate(any signal);
+    void DustGate_destroy(sig_Allocator allocator, sig_dsp_DustGate signal);
+
+    void ClockDetector_Outputs_newAudioBlocks(sig_Allocator allocator,
+        sig_AudioSettings audioSettings, sig_dsp_ClockDetector_Outputs outputs);
+    void ClockDetector_Outputs_destroyAudioBlocks(sig_Allocator allocator,
+        sig_dsp_ClockDetector_Outputs outputs);
+    void ClockDetector_init(sig_dsp_ClockDetector signal,
+        sig_SignalContext context);
+    sig_dsp_ClockDetector ClockDetector_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void ClockDetector_generate(any signal);
+    void ClockDetector_destroy(sig_Allocator allocator,
+        sig_dsp_ClockDetector signal);
+
+    sig_dsp_LinearToFreq LinearToFreq_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void LinearToFreq_init(sig_dsp_LinearToFreq signal,
+        sig_SignalContext context);
+    void LinearToFreq_generate(any signal);
+    void LinearToFreq_destroy(sig_Allocator allocator,
+        sig_dsp_LinearToFreq signal);
+
+    sig_dsp_Branch Branch_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void Branch_init(sig_dsp_Branch signal, sig_SignalContext context);
+    void Branch_generate(any signal);
+    void Branch_destroy(sig_Allocator allocator, sig_dsp_Branch signal);
+
+    void List_Outputs_newAudioBlocks(sig_Allocator allocator,
+        sig_AudioSettings audioSettings, sig_dsp_List_Outputs outputs);
+    void List_Outputs_destroyAudioBlocks(sig_Allocator allocator,
+        sig_dsp_List_Outputs outputs);
+    sig_dsp_List List_new(sig_Allocator allocator, sig_SignalContext context);
+    void List_init(sig_dsp_List signal, sig_SignalContext context);
+    float List_constrain(boolean shouldWrap, float index,
+        float lastIndex, float listLength);
+    void List_generate(any signal);
+    void List_destroy(sig_Allocator allocator, sig_dsp_List signal);
+
+    sig_dsp_LinearMap LinearMap_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void LinearMap_init(sig_dsp_LinearMap signal, sig_SignalContext context);
+    void LinearMap_generate(any signal);
+    void LinearMap_destroy(sig_Allocator allocator, sig_dsp_LinearMap signal);
+
+    sig_dsp_TwoOpFM TwoOpFM_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void TwoOpFM_init(sig_dsp_TwoOpFM signal, sig_SignalContext context);
+    void TwoOpFM_generate(any signal);
+    void TwoOpFM_destroy(sig_Allocator allocator, sig_dsp_TwoOpFM signal);
+
+    void OnePole_init(sig_dsp_OnePole signal, sig_SignalContext context);
+    sig_dsp_OnePole OnePole_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void OnePole_recalculateCoefficients(sig_dsp_OnePole signal,
+        float frequency);
+    void OnePole_generate(any signal);
+    void OnePole_destroy(sig_Allocator allocator, sig_dsp_OnePole signal);
+
+    void FourPoleFilter_Outputs_newAudioBlocks(sig_Allocator allocator,
+        sig_AudioSettings audioSettings,
+        sig_dsp_FourPoleFilter_Outputs outputs);
+    void FourPoleFilter_Outputs_destroyAudioBlocks(sig_Allocator allocator,
+         sig_dsp_FourPoleFilter_Outputs outputs);
+
+    sig_dsp_Bob Bob_new(sig_Allocator allocator, sig_SignalContext context);
+    void Bob_init(sig_dsp_Bob signal, sig_SignalContext context);
+    float Bob_clip(float value, float saturation, float saturationInv);
+    void Bob_generate(any signal);
+    void Bob_destroy(sig_Allocator allocator, sig_dsp_Bob signal);
+
+    sig_dsp_Ladder Ladder_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void Ladder_init(sig_dsp_Ladder signal, sig_SignalContext context);
+    void Ladder_calcCoefficients(sig_dsp_Ladder signal, float freq);
+    float Ladder_calcStage(sig_dsp_Ladder signal, float s, octet i);
+    void Ladder_generate(any signal);
+    void Ladder_destroy(sig_Allocator allocator, sig_dsp_Ladder signal);
+
+    sig_dsp_TiltEQ TiltEQ_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void TiltEQ_init(sig_dsp_TiltEQ signal, sig_SignalContext context);
+    void TiltEQ_generate(any signal);
+    void TiltEQ_destroy(sig_Allocator allocator, sig_dsp_TiltEQ signal);
+
+    sig_dsp_Delay Delay_new(sig_Allocator allocator, sig_SignalContext context);
+    void Delay_init(sig_dsp_Delay signal, sig_SignalContext context);
+    void Delay_read(sig_dsp_Delay signal, float source, unsigned long i);
+    void Delay_generate(any signal);
+    void Delay_destroy(sig_Allocator allocator, sig_dsp_Delay signal);
+
+    sig_dsp_Delay DelayTap_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void DelayTap_init(sig_dsp_Delay signal, sig_SignalContext context);
+    void DelayTap_generate(any signal);
+    void DelayTap_destroy(sig_Allocator allocator, sig_dsp_Delay signal);
+
+    sig_dsp_DelayWrite DelayWrite_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void DelayWrite_init(sig_dsp_DelayWrite signal, sig_SignalContext context);
+    void DelayWrite_generate(any signal);
+    void DelayWrite_destroy(sig_Allocator allocator, sig_dsp_DelayWrite signal);
+
+    sig_dsp_Comb Comb_new(sig_Allocator allocator, sig_SignalContext context);
+    void Comb_init(sig_dsp_Comb signal, sig_SignalContext context);
+    void Comb_generate(any signal);
+    void Comb_destroy(sig_Allocator allocator, sig_dsp_Comb signal);
+
+    sig_dsp_Allpass Allpass_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void Allpass_init(sig_dsp_Allpass signal, sig_SignalContext context);
+    void Allpass_generate(any signal);
+    void Allpass_destroy(sig_Allocator allocator, sig_dsp_Allpass signal);
+
+    sig_dsp_Chorus Chorus_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void Chorus_init(sig_dsp_Chorus signal, sig_SignalContext context);
+    void Chorus_generate(any signal);
+    void Chorus_destroy(sig_Allocator allocator, sig_dsp_Chorus signal);
+
+    sig_dsp_LinearXFade LinearXFade_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void LinearXFade_init(sig_dsp_LinearXFade signal, sig_SignalContext context);
+    void LinearXFade_generate(any signal);
+    void LinearXFade_destroy(sig_Allocator allocator, sig_dsp_LinearXFade signal);
+
+    void Calibrator_Node_init(sig_dsp_Calibrator_Node nodes, any targetValues,
+        unsigned long numNodes);
+    unsigned long Calibrator_locateIntervalForValue(float x,
+        sig_dsp_Calibrator_Node nodes, unsigned long numNodes);
+    float Calibrator_fitValueToCalibrationData(float x, sig_dsp_Calibrator_Node nodes, unsigned long numNodes);
+    sig_dsp_Calibrator Calibrator_new(sig_Allocator allocator,
+        sig_SignalContext context);
+    void Calibrator_init(sig_dsp_Calibrator signal, sig_SignalContext context);
+    void Calibrator_generate(any signal);
+    void Calibrator_destroy(sig_Allocator allocator, sig_dsp_Calibrator signal);
+};
+
+interface Signaletic {
+    void Signaletic();
+
+    [Value] attribute Signals dsp;
+
+    readonly attribute float PI;
+    readonly attribute float TWOPI;
+    readonly attribute float RECIP_TWOPI;
+    readonly attribute float LOG0_001;
+    readonly attribute float LOG2;
+    readonly attribute float FREQ_C4;
+
+    [Value] readonly attribute sig_AudioSettings DEFAULT_AUDIOSETTINGS;
+
+    sig_Status Status_new(sig_Allocator allocator);
+    void Status_init(sig_Status status);
+    void Status_reset(sig_Status status);
+    void Status_reportResult(sig_Status status, sig_Result result);
+
+    float fminf(float a, float b);
+    float fmaxf(float a, float b);
+    float clamp(float value, float min, float max);
+    float flooredfmodf(float num, float denom);
+    float randf();
+    float fastTanhf(float x);
+    float linearMap(float value, float fromMin, float fromMax, float toMin,
+        float toMax);
+    unsigned short unipolarToUint12(float sample);
+    unsigned short bipolarToUint12(float sample);
+    unsigned short bipolarToInvUint12(float sample);
+    float uint16ToBipolar(unsigned short sample);
+    float uint16ToUnipolar(unsigned short sample);
+    float invUint16ToBipolar(unsigned short sample);
+    float midiToFreq(float midiNum);
+    float freqToMidi(float frequency);
+    float linearToFreq(float value, float middleFreq);
+    float freqToLinear(float freq, float middleFreq);
+    float sum(any values, unsigned long length);
+    unsigned long indexOfMin(any values, unsigned long length);
+    unsigned long indexOfMax(any values, unsigned long length);
+
+    float randomFill(unsigned long i, any array);
+    void fillWithValue(any array, unsigned long length, float value);
+    void fillWithSilence(any array, unsigned long length);
+    float interpolate_linear(float idx, any table, unsigned long length);
+    float interpolate_cubic(float idx, any table, unsigned long length);
+    float filter_mean(any values, unsigned long length);
+    float filter_meanExcludeMinMax(any values, unsigned long length);
+    float filter_ema(float current, float previous, float a);
+    float filter_onepole(float current, float previous, float b0, float a1);
+    float filter_onepole_HPF_calculateA1(float frequency, float sampleRate);
+    float filter_onepole_HPF_calculateB0(float a1);
+    float filter_onepole_LPF_calculateA1(float frequency, float sampleRate);
+    float filter_onepole_LPF_calculateB0(float a1);
+    float filter_smooth(float current, float previous, float coeff);
+    float filter_smooth_calculateCoefficient(float timeSecs, float sampleRate);
+
+    void filter_Smooth_init(sig_filter_Smooth smooth, float coeff);
+    float filter_Smooth_generate(sig_filter_Smooth smooth, float value);
+
+    float waveform_sine(float phase);
+    float waveform_square(float phase);
+    float waveform_saw(float phase);
+    float waveform_reverseSaw(float phase);
+    float waveform_triangle(float phase);
+
+    void osc_FastLFSine_init(sig_osc_FastLFSine signal, float sampleRate);
+    void osc_FastLFSine_setFrequency(sig_osc_FastLFSine signal,
+        float frequency);
+    void osc_FastLFSine_setFrequencyFast(sig_osc_FastLFSine signal,
+        float frequency);
+    void osc_FastLFSine_generate(sig_osc_FastLFSine signal);
+
+    unsigned long secondsToSamples(sig_AudioSettings audioSettings,
+        float duration);
+
+    sig_Allocator TLSFAllocator_new(unsigned long size);
+    void TLSFAllocator_destroy(sig_Allocator allocator);
+
+    sig_List List_new(sig_Allocator allocator,
+        unsigned long capacity);
+    void List_insert(sig_List list, unsigned long index, any item,
+        sig_Status status);
+    void List_append(sig_List list, any item, sig_Status status);
+    any List_pop(sig_List list, sig_Status status);
+    any List_remove(sig_List list, unsigned long index, sig_Status status);
+    void List_destroy(sig_Allocator allocator, sig_List list);
+
+    sig_AudioSettings AudioSettings_new(sig_Allocator allocator);
+    void AudioSettings_destroy(sig_Allocator allocator,
+        sig_AudioSettings settings);
+
+    sig_SignalContext SignalContext_new(sig_Allocator allocator, sig_AudioSettings audioSettings);
+    void SignalContext_destroy(sig_Allocator allocator,
+        sig_SignalContext context);
+
+    sig_Buffer Buffer_new(sig_Allocator allocator, unsigned long length);
+    void Buffer_fillWithValue(sig_Buffer buffer, float value);
+    void Buffer_fillWithSilence(sig_Buffer buffer);
+    float Buffer_read(sig_Buffer buffer, float idx);
+    float Buffer_readLinear(sig_Buffer buffer, float idx);
+    float Buffer_readCubic(sig_Buffer buffer, float idx);
+    void Buffer_destroy(sig_Allocator allocator, sig_Buffer buffer);
+
+    sig_Buffer BufferView_new(sig_Allocator allocator, sig_Buffer buffer, unsigned long startIdx, unsigned long length);
+    void BufferView_destroy(sig_Allocator allocator, sig_Buffer buffer);
+
+    any AudioBlock_new(sig_Allocator allocator,
+        sig_AudioSettings audioSettings);
+    any AudioBlock_newWithValue(sig_Allocator allocator,
+        sig_AudioSettings audioSettings, float value);
+    any AudioBlock_newSilent(sig_Allocator allocator,
+        sig_AudioSettings audioSettings);
+    void AudioBlock_destroy(sig_Allocator allocator, any audioBlock);
+
+    sig_DelayLine DelayLine_new(sig_Allocator allocator,
+        unsigned long maxDelayLength);
+    sig_DelayLine DelayLine_newSeconds(sig_Allocator allocator, sig_AudioSettings audioSettings, float maxDelaySecs);
+    sig_DelayLine DelayLine_newWithTransferredBuffer(sig_Allocator allocator,
+        sig_Buffer buffer);
+    void DelayLine_init(sig_DelayLine delayLine);
+    float DelayLine_readAt(sig_DelayLine delayLine, unsigned long readPos);
+    float DelayLine_linearReadAt(sig_DelayLine delayLine, float readPos);
+    float DelayLine_cubicReadAt(sig_DelayLine delayLine, float readPos);
+    float DelayLine_allpassReadAt(sig_DelayLine delayLine, float readPos,
+        float previousSample);
+    float DelayLine_readAtTime(sig_DelayLine delayLine, float source,
+        float tapTime, float sampleRate);
+    float DelayLine_linearReadAtTime(sig_DelayLine delayLine, float source,
+        float tapTime, float sampleRate);
+    float DelayLine_cubicReadAtTime(sig_DelayLine delayLine, float source,
+        float tapTime, float sampleRate);
+    float DelayLine_allpassReadAtTime(sig_DelayLine delayLine, float source,
+        float tapTime, float sampleRate, float previousSample);
+    float DelayLine_readAtTimes(sig_DelayLine delayLine, float source,
+        any tapTimes, any tapGains, unsigned long numTaps, float sampleRate,
+        float timeScale);
+    float DelayLine_linearReadAtTimes(sig_DelayLine delayLine, float source,
+        any tapTimes, any tapGains, unsigned long numTaps, float sampleRate,
+        float timeScale);
+    float DelayLine_cubicReadAtTimes(sig_DelayLine delayLine, float source,
+        any tapTimes, any tapGains, unsigned long numTaps, float sampleRate,
+        float timeScale);
+
+    void DelayLine_write(sig_DelayLine delayLine, float sample);
+    float DelayLine_calcFeedbackGain(float delayTime, float decayTime);
+    float DelayLine_feedback(float sample, float read, float g);
+    float DelayLine_comb(sig_DelayLine delayLine, float sample,
+        unsigned long readPos, float g);
+    float DelayLine_cubicComb(sig_DelayLine delayLine, float sample,
+        float readPos, float g);
+    float DelayLine_allpass(sig_DelayLine delayLine, float sample,
+        unsigned long readPos, float g);
+    float DelayLine_linearAllpass(sig_DelayLine delayLine, float sample,
+        float readPos, float g);
+    float DelayLine_cubicAllpass(sig_DelayLine delayLine, float sample,
+        float readPos, float g);
+    void DelayLine_destroy(sig_Allocator allocator, sig_DelayLine delayLine);
+
+    float linearXFade(float left, float right, float mix);
+};

--- a/libsignaletic/wasm/bindings/src/libsignaletic-web.cpp
+++ b/libsignaletic/wasm/bindings/src/libsignaletic-web.cpp
@@ -5,8 +5,44 @@
 
 class Signals {
 public:
+    void Signal_SingleMonoOutput_newAudioBlocks(
+        struct sig_Allocator* allocator,
+        struct sig_AudioSettings* audioSettings,
+        struct sig_dsp_Signal_SingleMonoOutput* outputs) {
+        sig_dsp_Signal_SingleMonoOutput_newAudioBlocks(allocator,
+            audioSettings, outputs);
+    }
+
+    void Signal_SingleMonoOutput_destroyAudioBlocks(
+        struct sig_Allocator* allocator,
+        struct sig_dsp_Signal_SingleMonoOutput* outputs) {
+        sig_dsp_Signal_SingleMonoOutput_destroyAudioBlocks(allocator,
+            outputs);
+    }
+
     void evaluateSignals(struct sig_List* signalList) {
         return sig_dsp_evaluateSignals(signalList);
+    }
+
+    struct sig_dsp_SignalListEvaluator* SignalListEvaluator_new(
+        struct sig_Allocator* allocator, struct sig_List* signalList) {
+        return sig_dsp_SignalListEvaluator_new(allocator, signalList);
+    }
+
+    void SignalListEvaluator_init(
+        struct sig_dsp_SignalListEvaluator* self,
+        struct sig_List* signalList) {
+        sig_dsp_SignalListEvaluator_init(self, signalList);
+    }
+
+    void SignalListEvaluator_evaluate(
+        struct sig_dsp_SignalEvaluator* self) {
+        sig_dsp_SignalListEvaluator_evaluate(self);
+    }
+
+    void SignalListEvaluator_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_SignalListEvaluator* self) {
+        sig_dsp_SignalListEvaluator_destroy(allocator, self);
     }
 
     struct sig_dsp_Value* Value_new(
@@ -15,14 +51,90 @@ public:
         return sig_dsp_Value_new(allocator, context);
     }
 
+    void Value_init(struct sig_dsp_Value* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Value_init(self, context);
+    }
+
+    void Value_generate(void* signal) {
+        sig_dsp_Value_generate(signal);
+    }
+
     void Value_destroy(struct sig_Allocator* allocator,
         struct sig_dsp_Value* self) {
         return sig_dsp_Value_destroy(allocator, self);
     }
 
-    struct sig_dsp_BinaryOp* Add_new(struct sig_Allocator* allocator,
+    struct sig_dsp_ConstantValue* ConstantValue_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context,
+        float value) {
+        return sig_dsp_ConstantValue_new(allocator, context, value);
+    }
+
+    void ConstantValue_init(struct sig_dsp_ConstantValue* self,
+        struct sig_SignalContext* context, float value) {
+        sig_dsp_ConstantValue_init(self, context, value);
+    }
+
+    void ConstantValue_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_ConstantValue* self) {
+        return sig_dsp_ConstantValue_destroy(allocator, self);
+    }
+
+    struct sig_dsp_Abs* Abs_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_Abs_new(allocator, context);
+    }
+
+    void Abs_init(struct sig_dsp_Abs* self,
+        struct sig_SignalContext* context) {
+            sig_dsp_Abs_init(self, context);
+    }
+
+    void Abs_generate(void* signal) {
+        sig_dsp_Abs_generate(signal);
+    }
+
+    void Abs_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_Abs* self) {
+        return sig_dsp_Abs_destroy(allocator, self);
+    }
+
+    struct sig_dsp_ScaleOffset* ScaleOffset_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_ScaleOffset_new(allocator, context);
+    }
+
+    void ScaleOffset_init(struct sig_dsp_ScaleOffset* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_ScaleOffset_init(self, context);
+    }
+
+    void ScaleOffset_generate(void* signal) {
+        sig_dsp_ScaleOffset_generate(signal);
+    }
+
+    void ScaleOffset_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_ScaleOffset* self) {
+        return sig_dsp_ScaleOffset_destroy(allocator, self);
+    }
+
+    struct sig_dsp_BinaryOp* Add_new(
+        struct sig_Allocator* allocator,
         struct sig_SignalContext* context) {
         return sig_dsp_Add_new(allocator, context);
+    }
+
+    void Add_init(struct sig_dsp_BinaryOp* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Add_init(self, context);
+    }
+
+    void Add_generate(void* signal) {
+        sig_dsp_Add_generate(signal);
     }
 
     void Add_destroy(struct sig_Allocator* allocator,
@@ -30,9 +142,39 @@ public:
         return sig_dsp_Add_destroy(allocator, self);
     }
 
-    struct sig_dsp_BinaryOp* Mul_new(struct sig_Allocator* allocator,
+    struct sig_dsp_BinaryOp* Sub_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_Sub_new(allocator, context);
+    }
+
+    void Sub_init(struct sig_dsp_BinaryOp* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Sub_init(self, context);
+    }
+
+    void Sub_generate(void* signal) {
+        sig_dsp_Sub_generate(signal);
+    }
+
+    void Sub_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_BinaryOp* self) {
+        return sig_dsp_Sub_destroy(allocator, self);
+    }
+
+    struct sig_dsp_BinaryOp* Mul_new(
+        struct sig_Allocator* allocator,
         struct sig_SignalContext* context) {
         return sig_dsp_Mul_new(allocator, context);
+    }
+
+    void Mul_init(struct sig_dsp_BinaryOp* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Mul_init(self, context);
+    }
+
+    void Mul_generate(void* signal) {
+        sig_dsp_Mul_generate(signal);
     }
 
     void Mul_destroy(struct sig_Allocator* allocator,
@@ -40,9 +182,19 @@ public:
         return sig_dsp_Mul_destroy(allocator, self);
     }
 
-    struct sig_dsp_BinaryOp* Div_new(struct sig_Allocator* allocator,
+    struct sig_dsp_BinaryOp* Div_new(
+        struct sig_Allocator* allocator,
         struct sig_SignalContext* context) {
         return sig_dsp_Div_new(allocator, context);
+    }
+
+    void Div_init(struct sig_dsp_BinaryOp* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Div_init(self, context);
+    }
+
+    void Div_generate(void* signal) {
+        sig_dsp_Div_generate(signal);
     }
 
     void Div_destroy(struct sig_Allocator* allocator,
@@ -50,9 +202,151 @@ public:
         return sig_dsp_Div_destroy(allocator, self);
     }
 
+    struct sig_dsp_Invert* Invert_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_Invert_new(allocator, context);
+    }
+
+    void Invert_init(struct sig_dsp_Invert* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Invert_init(self, context);
+    }
+
+    void Invert_generate(void* signal) {
+        sig_dsp_Invert_generate(signal);
+    }
+
+    void Invert_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_Invert* self) {
+        return sig_dsp_Invert_destroy(allocator, self);
+    }
+
+    struct sig_dsp_Accumulate* Accumulate_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_Accumulate_new(allocator, context);
+    }
+
+    void Accumulate_init(struct sig_dsp_Accumulate* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Accumulate_init(self, context);
+    }
+
+    void Accumulate_generate(void* signal) {
+        sig_dsp_Accumulate_generate(signal);
+    }
+
+    void Accumulate_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_Accumulate* self) {
+        return sig_dsp_Accumulate_destroy(allocator, self);
+    }
+
+    struct sig_dsp_GatedTimer* GatedTimer_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_GatedTimer_new(allocator, context);
+    }
+
+    void GatedTimer_init(struct sig_dsp_GatedTimer* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_GatedTimer_init(self, context);
+    }
+
+    void GatedTimer_generate(void* signal) {
+        sig_dsp_GatedTimer_generate(signal);
+    }
+
+    void GatedTimer_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_GatedTimer* self) {
+        return sig_dsp_GatedTimer_destroy(allocator, self);
+    }
+
+    struct sig_dsp_TimedTriggerCounter* TimedTriggerCounter_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_TimedTriggerCounter_new(allocator, context);
+    }
+
+    void TimedTriggerCounter_init(
+        struct sig_dsp_TimedTriggerCounter* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_TimedTriggerCounter_init(self, context);
+    }
+
+    void TimedTriggerCounter_generate(void* signal) {
+        sig_dsp_TimedTriggerCounter_generate(signal);
+    }
+
+    void TimedTriggerCounter_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_TimedTriggerCounter* self) {
+        return sig_dsp_TimedTriggerCounter_destroy(allocator, self);
+    }
+
+    struct sig_dsp_ToggleGate* ToggleGate_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_ToggleGate_new(allocator, context);
+    }
+
+    void ToggleGate_init(struct sig_dsp_ToggleGate* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_ToggleGate_init(self, context);
+    }
+
+    void ToggleGate_generate(void* signal) {
+        sig_dsp_ToggleGate_generate(signal);
+    }
+
+    void ToggleGate_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_ToggleGate* self) {
+        return sig_dsp_ToggleGate_destroy(allocator, self);
+    }
+
+    void Oscillator_Outputs_newAudioBlocks(
+        struct sig_Allocator* allocator,
+        struct sig_AudioSettings* audioSettings,
+        struct sig_dsp_Oscillator_Outputs* outputs) {
+        sig_dsp_Oscillator_Outputs_newAudioBlocks(allocator, audioSettings,
+            outputs);
+    }
+
+    void Oscillator_Outputs_destroyAudioBlocks(
+        struct sig_Allocator* allocator,
+        struct sig_dsp_Oscillator_Outputs* outputs) {
+        sig_dsp_Oscillator_Outputs_destroyAudioBlocks(allocator, outputs);
+    }
+
+    float Oscillator_eoc(float phase) {
+        return sig_dsp_Oscillator_eoc(phase);
+    }
+
+    float Oscillator_wrapPhase(float phase) {
+        return sig_dsp_Oscillator_wrapPhase(phase);
+    }
+
+    void Oscillator_accumulatePhase(struct sig_dsp_Oscillator* self,
+        size_t i) {
+        sig_dsp_Oscillator_accumulatePhase(self, i);
+    }
+
+    void Oscillator_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_Oscillator* self) {
+        sig_dsp_Oscillator_destroy(allocator, self);
+    }
+
     struct sig_dsp_Oscillator* Sine_new(struct sig_Allocator* allocator,
         struct sig_SignalContext* context) {
         return sig_dsp_Sine_new(allocator, context);
+    }
+
+    void Sine_init(struct sig_dsp_Oscillator* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Sine_init(self, context);
+    }
+
+    void Sine_generate(void* signal) {
+        sig_dsp_Sine_generate(signal);
     }
 
     void Sine_destroy(struct sig_Allocator* allocator,
@@ -65,11 +359,195 @@ public:
         return sig_dsp_LFTriangle_new(allocator, context);
     }
 
+    void LFTriangle_init(struct sig_dsp_Oscillator* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_LFTriangle_init(self, context);
+    }
+
+    void LFTriangle_generate(void* signal) {
+        sig_dsp_LFTriangle_generate(signal);
+    }
+
     void LFTriangle_destroy(struct sig_Allocator* allocator,
         struct sig_dsp_Oscillator* self) {
         return sig_dsp_LFTriangle_destroy(allocator, self);
     }
 
+    struct sig_dsp_Smooth* Smooth_new(struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_Smooth_new(allocator, context);
+    }
+
+    void Smooth_init(struct sig_dsp_Smooth* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Smooth_init(self, context);
+    }
+
+    void Smooth_generate(void* signal) {
+        sig_dsp_Smooth_generate(signal);
+    }
+
+    void Smooth_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_Smooth* self) {
+        return sig_dsp_Smooth_destroy(allocator, self);
+    }
+
+    struct sig_dsp_EMA* EMA_new(struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_EMA_new(allocator, context);
+    }
+
+    void EMA_init(struct sig_dsp_EMA* self,
+        struct sig_SignalContext* context)  {
+        sig_dsp_EMA_init(self, context);
+    }
+
+    void EMA_generate(void* signal) {
+        sig_dsp_EMA_generate(signal);
+    }
+
+    void EMA_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_EMA* self) {
+        return sig_dsp_EMA_destroy(allocator, self);
+    }
+
+    struct sig_dsp_OnePole* OnePole_new(struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_OnePole_new(allocator, context);
+    }
+
+    void OnePole_init(struct sig_dsp_OnePole* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_OnePole_init(self, context);
+    }
+
+    void OnePole_recalculateCoefficients(struct sig_dsp_OnePole* self,
+        float frequency) {
+        sig_dsp_OnePole_recalculateCoefficients(self, frequency);
+    }
+
+    void OnePole_generate(void* signal) {
+        sig_dsp_OnePole_generate(signal);
+    }
+
+    void OnePole_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_OnePole* self) {
+        return sig_dsp_OnePole_destroy(allocator, self);
+    }
+
+    struct sig_dsp_Tanh* Tanh_new(struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_Tanh_new(allocator, context);
+    }
+
+    void Tanh_init(struct sig_dsp_Tanh* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Tanh_init(self, context);
+    }
+
+    void Tanh_generate(void* signal) {
+        sig_dsp_Tanh_generate(signal);
+    }
+
+    void Tanh_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_Tanh* self) {
+        return sig_dsp_Tanh_destroy(allocator, self);
+    }
+
+    struct sig_dsp_Looper* Looper_new(struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_Looper_new(allocator, context);
+    }
+
+    void Looper_init(struct sig_dsp_Looper* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Looper_init(self, context);
+    }
+
+    void Looper_setBuffer(struct sig_dsp_Looper* self,
+        struct sig_Buffer* buffer) {
+        sig_dsp_Looper_setBuffer(self, buffer);
+    }
+
+    void Looper_generate(void* signal) {
+        sig_dsp_Looper_generate(signal);
+    }
+
+    void Looper_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_Looper* self) {
+        return sig_dsp_Looper_destroy(allocator, self);
+    }
+
+    struct sig_dsp_Dust* Dust_new(struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_Dust_new(allocator, context);
+    }
+
+    void Dust_init(struct sig_dsp_Dust* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Dust_init(self, context);
+    }
+
+    void Dust_generate(void* signal) {
+        sig_dsp_Dust_generate(signal);
+    }
+
+    void Dust_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_Dust* self) {
+        return sig_dsp_Dust_destroy(allocator, self);
+    }
+
+    struct sig_dsp_TimedGate* TimedGate_new(struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_TimedGate_new(allocator, context);
+    }
+
+    void TimedGate_init(struct sig_dsp_TimedGate* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_TimedGate_init(self, context);
+    }
+
+    void TimedGate_generate(void* signal) {
+        sig_dsp_TimedGate_generate(signal);
+    }
+
+    void TimedGate_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_TimedGate* self) {
+        return sig_dsp_TimedGate_destroy(allocator, self);
+    }
+
+    struct sig_dsp_DustGate* DustGate_new(struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_DustGate_new(allocator, context);
+    }
+
+    void DustGate_init(struct sig_dsp_DustGate* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_DustGate_init(self, context);
+    }
+
+    void DustGate_generate(void* signal) {
+        sig_dsp_DustGate_generate(signal);
+    }
+
+    void DustGate_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_DustGate* self) {
+        return sig_dsp_DustGate_destroy(allocator, self);
+    }
+
+    void ClockDetector_Outputs_newAudioBlocks(
+        struct sig_Allocator* allocator,
+        struct sig_AudioSettings* audioSettings,
+        struct sig_dsp_ClockDetector_Outputs* outputs) {
+        sig_dsp_ClockDetector_Outputs_newAudioBlocks(allocator, audioSettings,
+            outputs);
+    }
+
+    void ClockDetector_Outputs_destroyAudioBlocks(
+        struct sig_Allocator* allocator,
+        struct sig_dsp_ClockDetector_Outputs* outputs) {
+        sig_dsp_ClockDetector_Outputs_destroyAudioBlocks(allocator, outputs);
+    }
 
     struct sig_dsp_ClockDetector* ClockDetector_new(
         struct sig_Allocator* allocator,
@@ -77,20 +555,417 @@ public:
         return sig_dsp_ClockDetector_new(allocator, context);
     }
 
+    void ClockDetector_init(struct sig_dsp_ClockDetector* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_ClockDetector_init(self, context);
+    }
+
+    void ClockDetector_generate(void* signal) {
+        sig_dsp_ClockDetector_generate(signal);
+    }
+
     void ClockDetector_destroy(struct sig_Allocator* allocator,
         struct sig_dsp_ClockDetector* self) {
         return sig_dsp_ClockDetector_destroy(allocator, self);
+    }
+
+    struct sig_dsp_LinearToFreq* LinearToFreq_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_LinearToFreq_new(allocator, context);
+    }
+
+    void LinearToFreq_init(struct sig_dsp_LinearToFreq* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_LinearToFreq_init(self, context);
+    }
+
+    void LinearToFreq_generate(void* signal) {
+        sig_dsp_LinearToFreq_generate(signal);
+    }
+
+    void LinearToFreq_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_LinearToFreq* self) {
+        return sig_dsp_LinearToFreq_destroy(allocator, self);
+    }
+
+    struct sig_dsp_Branch* Branch_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_Branch_new(allocator, context);
+    }
+
+    void Branch_init(struct sig_dsp_Branch* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Branch_init(self, context);
+    }
+
+    void Branch_generate(void* signal) {
+        sig_dsp_Branch_generate(signal);
+    }
+
+    void Branch_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_Branch* self) {
+        return sig_dsp_Branch_destroy(allocator, self);
+    }
+
+    void List_Outputs_newAudioBlocks(struct sig_Allocator* allocator,
+        struct sig_AudioSettings* audioSettings,
+        struct sig_dsp_List_Outputs* outputs) {
+        sig_dsp_List_Outputs_newAudioBlocks(allocator, audioSettings, outputs);
+    }
+
+    void List_Outputs_destroyAudioBlocks(struct sig_Allocator* allocator,
+        struct sig_dsp_List_Outputs* outputs) {
+        sig_dsp_List_Outputs_destroyAudioBlocks(allocator, outputs);
+    }
+
+    struct sig_dsp_List* List_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_List_new(allocator, context);
+    }
+
+    void List_init(struct sig_dsp_List* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_List_init(self, context);
+    }
+
+    float List_constrain(bool shouldWrap, float index,
+        float lastIndex, float listLength) {
+        return sig_dsp_List_constrain(shouldWrap, index, lastIndex, listLength);
+    }
+
+    void List_generate(void* signal) {
+        sig_dsp_List_generate(signal);
+    }
+
+    void List_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_List* self) {
+        return sig_dsp_List_destroy(allocator, self);
+    }
+
+    struct sig_dsp_LinearMap* LinearMap_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_LinearMap_new(allocator, context);
+    }
+
+    void LinearMap_init(struct sig_dsp_LinearMap* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_LinearMap_init(self, context);
+    }
+
+    void LinearMap_generate(void* signal) {
+        sig_dsp_LinearMap_generate(signal);
+    }
+
+    void LinearMap_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_LinearMap* self) {
+        return sig_dsp_LinearMap_destroy(allocator, self);
+    }
+
+    struct sig_dsp_TwoOpFM* TwoOpFM_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_TwoOpFM_new(allocator, context);
+    }
+
+    void TwoOpFM_init(struct sig_dsp_TwoOpFM* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_TwoOpFM_init(self, context);
+    }
+
+    void TwoOpFM_generate(void* signal) {
+        sig_dsp_TwoOpFM_generate(signal);
+    }
+
+    void TwoOpFM_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_TwoOpFM* self) {
+        return sig_dsp_TwoOpFM_destroy(allocator, self);
+    }
+
+    void FourPoleFilter_Outputs_newAudioBlocks(
+        struct sig_Allocator* allocator,
+        struct sig_AudioSettings* audioSettings,
+        struct sig_dsp_FourPoleFilter_Outputs* outputs) {
+        sig_dsp_FourPoleFilter_Outputs_newAudioBlocks(allocator,
+            audioSettings, outputs);
+    }
+
+    void FourPoleFilter_Outputs_destroyAudioBlocks(
+        struct sig_Allocator* allocator,
+        struct sig_dsp_FourPoleFilter_Outputs* outputs) {
+        sig_dsp_FourPoleFilter_Outputs_destroyAudioBlocks(allocator, outputs);
+    }
+
+    struct sig_dsp_Bob* Bob_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_Bob_new(allocator, context);
+    }
+
+    void Bob_init(struct sig_dsp_Bob* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Bob_init(self, context);
+    }
+
+    float Bob_clip(float value, float saturation,
+        float saturationInv) {
+        return sig_dsp_Bob_clip(value, saturation, saturationInv);
+    }
+
+    void Bob_generate(void* signal) {
+        sig_dsp_Bob_generate(signal);
+    }
+
+    void Bob_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_Bob* self) {
+        return sig_dsp_Bob_destroy(allocator, self);
+    }
+
+    struct sig_dsp_Ladder* Ladder_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_Ladder_new(allocator, context);
+    }
+
+    void Ladder_init(
+        struct sig_dsp_Ladder* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Ladder_init(self, context);
+    }
+
+    void Ladder_calcCoefficients(
+        struct sig_dsp_Ladder* self, float freq) {
+        sig_dsp_Ladder_calcCoefficients(self, freq);
+    }
+
+    float Ladder_calcStage(
+        struct sig_dsp_Ladder* self, float s, uint8_t i) {
+        return sig_dsp_Ladder_calcStage(self, s, i);
+    }
+
+    void Ladder_generate(void* signal) {
+        sig_dsp_Ladder_generate(signal);
+    }
+
+    void Ladder_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_Ladder* self) {
+        return sig_dsp_Ladder_destroy(allocator, self);
+    }
+
+    struct sig_dsp_TiltEQ* TiltEQ_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_TiltEQ_new(allocator, context);
+    }
+
+    void TiltEQ_init(struct sig_dsp_TiltEQ* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_TiltEQ_init(self, context);
+    }
+
+    void TiltEQ_generate(void* signal) {
+        sig_dsp_TiltEQ_generate(signal);
+    }
+
+    void TiltEQ_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_TiltEQ* self) {
+        return sig_dsp_TiltEQ_destroy(allocator, self);
+    }
+
+    struct sig_dsp_Delay* Delay_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_Delay_new(allocator, context);
+    }
+
+    void Delay_init(struct sig_dsp_Delay* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Delay_init(self, context);
+    }
+
+    void Delay_read(struct sig_dsp_Delay* self, float source,
+        size_t i) {
+        sig_dsp_Delay_read(self, source, i);
+    }
+
+    void Delay_generate(void* signal) {
+        sig_dsp_Delay_generate(signal);
+    }
+
+    void Delay_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_Delay* self) {
+        return sig_dsp_Delay_destroy(allocator, self);
+    }
+
+    struct sig_dsp_Delay* DelayTap_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_DelayTap_new(allocator, context);
+    }
+
+    void DelayTap_init(struct sig_dsp_Delay* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_DelayTap_init(self, context);
+    }
+
+    void DelayTap_generate(void* signal) {
+        sig_dsp_DelayTap_generate(signal);
+    }
+
+    void DelayTap_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_Delay* self) {
+        return sig_dsp_DelayTap_destroy(allocator, self);
+    }
+
+    struct sig_dsp_DelayWrite* DelayWrite_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_DelayWrite_new(allocator, context);
+    }
+
+    void DelayWrite_init(struct sig_dsp_DelayWrite* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_DelayWrite_init(self, context);
+    }
+
+    void DelayWrite_generate(void* signal) {
+        sig_dsp_DelayWrite_generate(signal);
+    }
+
+    void DelayWrite_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_DelayWrite* self) {
+        return sig_dsp_DelayWrite_destroy(allocator, self);
+    }
+
+    struct sig_dsp_Comb* Comb_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_Comb_new(allocator, context);
+    }
+
+    void Comb_init(struct sig_dsp_Comb* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Comb_init(self, context);
+    }
+
+    void Comb_generate(void* signal) {
+        sig_dsp_Comb_generate(signal);
+    }
+
+    void Comb_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_Comb* self) {
+        return sig_dsp_Comb_destroy(allocator, self);
+    }
+
+    struct sig_dsp_Allpass* Allpass_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_Allpass_new(allocator, context);
+    }
+
+    void Allpass_init(struct sig_dsp_Allpass* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Allpass_init(self, context);
+    }
+
+    void Allpass_generate(void* signal) {
+        sig_dsp_Allpass_generate(signal);
+    }
+
+    void Allpass_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_Allpass* self) {
+        return sig_dsp_Allpass_destroy(allocator, self);
+    }
+
+    struct sig_dsp_Chorus* Chorus_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_Chorus_new(allocator, context);
+    }
+
+    void Chorus_init(struct sig_dsp_Chorus* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Chorus_init(self, context);
+    }
+
+    void Chorus_generate(void* signal) {
+        sig_dsp_Chorus_generate(signal);
+    }
+
+    void Chorus_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_Chorus* self) {
+        return sig_dsp_Chorus_destroy(allocator, self);
+    }
+
+    struct sig_dsp_LinearXFade* LinearXFade_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_LinearXFade_new(allocator, context);
+    }
+
+    void LinearXFade_init(struct sig_dsp_LinearXFade* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_LinearXFade_init(self, context);
+    }
+
+    void LinearXFade_generate(void* signal) {
+        sig_dsp_LinearXFade_generate(signal);
+    }
+
+    void LinearXFade_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_LinearXFade* self) {
+        return sig_dsp_LinearXFade_destroy(allocator, self);
+    }
+
+    void Calibrator_Node_init(struct sig_dsp_Calibrator_Node* nodes,
+        float_array_ptr targetValues, size_t numNodes) {
+        sig_dsp_Calibrator_Node_init(nodes, targetValues, numNodes);
+    }
+
+    size_t Calibrator_locateIntervalForValue(float x,
+        struct sig_dsp_Calibrator_Node* nodes, size_t numNodes) {
+        return sig_dsp_Calibrator_locateIntervalForValue(x, nodes, numNodes);
+    }
+
+    float Calibrator_fitValueToCalibrationData(float x,
+        struct sig_dsp_Calibrator_Node* nodes, size_t numNodes) {
+        return sig_dsp_Calibrator_fitValueToCalibrationData(x, nodes, numNodes);
+    }
+
+    struct sig_dsp_Calibrator* Calibrator_new(
+        struct sig_Allocator* allocator,
+        struct sig_SignalContext* context) {
+        return sig_dsp_Calibrator_new(allocator, context);
+    }
+
+    void Calibrator_init(struct sig_dsp_Calibrator* self,
+        struct sig_SignalContext* context) {
+        sig_dsp_Calibrator_init(self, context);
+    }
+
+    void Calibrator_generate(void* signal) {
+        sig_dsp_Calibrator_generate(signal);
+    }
+
+    void Calibrator_destroy(struct sig_Allocator* allocator,
+        struct sig_dsp_Calibrator* self) {
+        return sig_dsp_Calibrator_destroy(allocator, self);
     }
 };
 
 class Signaletic {
 public:
-
     const float PI = sig_PI;
     const float TWOPI = sig_PI;
-
-    // TODO: How do we expose DEFAULT_AUDIO_SETTINGS
-    // here as a pointer?
+    const float RECIP_TWOPI = sig_RECIP_TWOPI;
+    const float LOG0_001 = sig_LOG0_001;
+    const float LOG2 = sig_LOG2;
+    const float FREQ_C4 = sig_FREQ_C4;
+    struct sig_AudioSettings DEFAULT_AUDIOSETTINGS =
+        sig_DEFAULT_AUDIOSETTINGS;
 
     Signals dsp;
 
@@ -124,12 +999,82 @@ public:
     float fmaxf(float a, float b) {
         return sig_fmaxf(a, b);
     }
+
     float clamp(float value, float min, float max) {
         return sig_clamp(value, min, max);
     }
 
+    float flooredfmodf(float num, float denom) {
+        return sig_flooredfmodf(num, denom);
+    }
+
+    float randf() {
+        return sig_randf();
+    }
+
+    float fastTanhf(float x) {
+        return sig_fastTanhf(x);
+    }
+
+    float linearMap(float value,
+        float fromMin, float fromMax, float toMin, float toMax) {
+        return sig_linearMap(value, fromMin, fromMax, toMin, toMax);
+    }
+
+    uint16_t unipolarToUint12(float sample) {
+        return sig_unipolarToUint12(sample);
+    }
+
+    uint16_t bipolarToUint12(float sample) {
+        return sig_bipolarToUint12(sample);
+    }
+
+    uint16_t bipolarToInvUint12(float sample) {
+        return sig_bipolarToInvUint12(sample);
+    }
+
+    float uint16ToBipolar(uint16_t sample) {
+        return sig_uint16ToBipolar(sample);
+    }
+
+    float uint16ToUnipolar(uint16_t sample) {
+        return sig_uint16ToUnipolar(sample);
+    }
+
+    float invUint16ToBipolar(uint16_t sample) {
+        return sig_invUint16ToBipolar(sample);
+    }
+
     float midiToFreq(float midiNum) {
         return sig_midiToFreq(midiNum);
+    }
+
+    float freqToMidi(float frequency) {
+        return sig_freqToMidi(frequency);
+    }
+
+    float linearToFreq(float value, float middleFreq) {
+        return sig_linearToFreq(value, middleFreq);
+    }
+
+    float freqToLinear(float freq, float middleFreq) {
+        return sig_freqToLinear(freq, middleFreq);
+    }
+
+    float sum(float_array_ptr values, size_t length) {
+        return sig_sum(values, length);
+    }
+
+    size_t indexOfMin(float_array_ptr values, size_t length) {
+        return sig_indexOfMin(values, length);
+    }
+
+    size_t indexOfMax(float_array_ptr values, size_t length) {
+        return sig_indexOfMax(values, length);
+    }
+
+    float randomFill(size_t i, float_array_ptr array) {
+        return sig_randomFill(i, array);
     }
 
     void fillWithValue(float_array_ptr array, size_t length,
@@ -151,8 +1096,55 @@ public:
         return sig_interpolate_cubic(idx, table, length);
     }
 
+    float filter_mean(float_array_ptr values, size_t length) {
+        return sig_filter_mean(values, length);
+    }
+
+    float filter_meanExcludeMinMax(float_array_ptr values, size_t length) {
+        return sig_filter_meanExcludeMinMax(values, length);
+    }
+
+    float filter_ema(float current, float previous, float a) {
+        return sig_filter_ema(current, previous, a);
+    }
+
+    float filter_onepole(float current, float previous, float b0,
+        float a1) {
+        return sig_filter_onepole(current, previous, b0, a1);
+    }
+
+    float filter_onepole_HPF_calculateA1(float frequency, float sampleRate) {
+        return sig_filter_onepole_HPF_calculateA1(frequency, sampleRate);
+    }
+
+
+    float filter_onepole_HPF_calculateB0(float a1) {
+        return sig_filter_onepole_HPF_calculateB0(a1);
+    }
+
+    float filter_onepole_LPF_calculateA1(float frequency, float sampleRate) {
+        return sig_filter_onepole_LPF_calculateA1(frequency, sampleRate);
+    }
+
+    float filter_onepole_LPF_calculateB0(float a1) {
+        return sig_filter_onepole_LPF_calculateB0(a1);
+    }
+
     float filter_smooth(float current, float previous, float coeff) {
         return sig_filter_smooth(current, previous, coeff);
+    }
+
+    float filter_smooth_calculateCoefficient(float timeSecs,
+        float sampleRate) {
+        return sig_filter_smooth_calculateCoefficient(timeSecs, sampleRate);
+    }
+
+    void filter_Smooth_init(struct sig_filter_Smooth* self, float coeff) {
+        sig_filter_Smooth_init(self, coeff);
+    }
+
+    float filter_Smooth_generate(struct sig_filter_Smooth* self, float value) {
+        return sig_filter_Smooth_generate(self, value);
     }
 
     float waveform_sine(float phase) {
@@ -173,6 +1165,30 @@ public:
 
     float waveform_triangle(float phase) {
         return sig_waveform_triangle(phase);
+    }
+
+    void osc_FastLFSine_init(struct sig_osc_FastLFSine* self,
+        float sampleRate) {
+        sig_osc_FastLFSine_init(self, sampleRate);
+    }
+
+    void osc_FastLFSine_setFrequency(struct sig_osc_FastLFSine* self,
+        float frequency) {
+        sig_osc_FastLFSine_setFrequency(self, frequency);
+    }
+
+    void osc_FastLFSine_setFrequencyFast(struct sig_osc_FastLFSine* self,
+        float frequency) {
+        sig_osc_FastLFSine_setFrequencyFast(self, frequency);
+    }
+
+    void osc_FastLFSine_generate(struct sig_osc_FastLFSine* self) {
+        sig_osc_FastLFSine_generate(self);
+    }
+
+    size_t secondsToSamples(struct sig_AudioSettings* audioSettings,
+        float duration) {
+        return sig_secondsToSamples(audioSettings, duration);
     }
 
     /**
@@ -212,7 +1228,6 @@ public:
         // we didn't create it (it's a global singleton).
         free(allocator);
     }
-
 
     struct sig_List* List_new(struct sig_Allocator* allocator,
         size_t capacity) {
@@ -272,7 +1287,7 @@ public:
         return sig_Buffer_new(allocator, length);
     }
 
-    void Buffer_fill(struct sig_Buffer* buffer, float value) {
+    void Buffer_fillWithValue(struct sig_Buffer* buffer, float value) {
         return sig_Buffer_fillWithValue(buffer, value);
     }
 
@@ -297,6 +1312,16 @@ public:
         return sig_Buffer_destroy(allocator, buffer);
     }
 
+    struct sig_Buffer* BufferView_new(
+        struct sig_Allocator* allocator, struct sig_Buffer* buffer,
+        size_t startIdx, size_t length) {
+        return sig_BufferView_new(allocator, buffer, startIdx, length);
+    }
+
+    void BufferView_destroy(struct sig_Allocator* allocator,
+        struct sig_Buffer* self) {
+        sig_BufferView_destroy(allocator, self);
+    }
 
     float_array_ptr AudioBlock_new(struct sig_Allocator* allocator,
         struct sig_AudioSettings* audioSettings) {
@@ -311,9 +1336,154 @@ public:
                 audioSettings, value);
     }
 
+    float_array_ptr AudioBlock_newSilent(struct sig_Allocator* allocator,
+        struct sig_AudioSettings* audioSettings) {
+        return sig_AudioBlock_newSilent(allocator, audioSettings);
+    }
+
     void AudioBlock_destroy(struct sig_Allocator* allocator,
         float_array_ptr self) {
         return sig_AudioBlock_destroy(allocator, self);
+    }
+
+    struct sig_DelayLine* DelayLine_new(struct sig_Allocator* allocator,
+        size_t maxDelayLength) {
+        return sig_DelayLine_new(allocator, maxDelayLength);
+    }
+
+    struct sig_DelayLine* DelayLine_newSeconds(struct sig_Allocator* allocator,
+        struct sig_AudioSettings* audioSettings, float maxDelaySecs) {
+        return sig_DelayLine_newSeconds(allocator, audioSettings, maxDelaySecs);
+    }
+
+    struct sig_DelayLine* DelayLine_newWithTransferredBuffer(
+        struct sig_Allocator* allocator, struct sig_Buffer* buffer) {
+        return sig_DelayLine_newWithTransferredBuffer(allocator, buffer);
+    }
+
+    void DelayLine_init(struct sig_DelayLine* self) {
+        sig_DelayLine_init(self);
+    }
+
+    float DelayLine_readAt(struct sig_DelayLine* self, size_t readPos) {
+        return sig_DelayLine_readAt(self, readPos);
+    }
+
+    float DelayLine_linearReadAt(struct sig_DelayLine* self, float readPos) {
+        return sig_DelayLine_linearReadAt(self, readPos);
+    }
+
+    float DelayLine_cubicReadAt(struct sig_DelayLine* self, float readPos) {
+        return sig_DelayLine_cubicReadAt(self, readPos);
+    }
+
+    float DelayLine_allpassReadAt(struct sig_DelayLine* self,
+        float readPos, float previousSample) {
+        return sig_DelayLine_allpassReadAt(self, readPos, previousSample);
+    }
+
+    float DelayLine_readAtTime(struct sig_DelayLine* self, float source,
+        float tapTime, float sampleRate) {
+        return sig_DelayLine_readAtTime(self, source, tapTime, sampleRate);
+    }
+
+    float DelayLine_linearReadAtTime(struct sig_DelayLine* self, float source,
+        float tapTime, float sampleRate) {
+        return sig_DelayLine_linearReadAtTime(self, source, tapTime,
+            sampleRate);
+    }
+
+    float DelayLine_cubicReadAtTime(struct sig_DelayLine* self, float source,
+        float tapTime, float sampleRate) {
+        return sig_DelayLine_cubicReadAtTime(self, source, tapTime, sampleRate);
+    }
+
+    float DelayLine_allpassReadAtTime(struct sig_DelayLine* self,
+        float source, float tapTime, float sampleRate, float previousSample) {
+        return sig_DelayLine_allpassReadAtTime(self, source, tapTime,
+            sampleRate, previousSample);
+    }
+
+    float DelayLine_readAtTimes(struct sig_DelayLine* self, float source,
+        float_array_ptr tapTimes, float_array_ptr tapGains, size_t numTaps,
+        float sampleRate, float timeScale) {
+        return sig_DelayLine_readAtTimes(self, source, tapTimes, tapGains,
+            numTaps, sampleRate, timeScale);
+    }
+
+    float DelayLine_linearReadAtTimes(struct sig_DelayLine* self,
+        float source, float_array_ptr tapTimes, float_array_ptr tapGains,
+        size_t numTaps, float sampleRate, float timeScale) {
+        return sig_DelayLine_linearReadAtTimes(self, source, tapTimes,
+            tapGains, numTaps, sampleRate, timeScale);
+    }
+
+    float DelayLine_cubicReadAtTimes(struct sig_DelayLine* self,
+        float source, float_array_ptr tapTimes, float_array_ptr tapGains,
+        size_t numTaps, float sampleRate, float timeScale) {
+        return sig_DelayLine_cubicReadAtTimes(self, source, tapTimes, tapGains,
+            numTaps, sampleRate, timeScale);
+    }
+
+    void DelayLine_write(struct sig_DelayLine* self, float sample) {
+        sig_DelayLine_write(self, sample);
+    }
+
+    float DelayLine_calcFeedbackGain(float delayTime, float decayTime) {
+        return sig_DelayLine_calcFeedbackGain(delayTime, decayTime);
+    }
+
+    float DelayLine_feedback(float sample, float read, float g) {
+        return sig_DelayLine_feedback(sample, read, g);
+    }
+
+    float DelayLine_comb(struct sig_DelayLine* self, float sample,
+        size_t readPos, float g) {
+        return sig_DelayLine_comb(self, sample, readPos, g);
+    }
+
+    float DelayLine_cubicComb(struct sig_DelayLine* self, float sample,
+        float readPos, float g) {
+        return sig_DelayLine_cubicComb(self, sample, readPos, g);
+    }
+
+    float DelayLine_allpass(struct sig_DelayLine* self, float sample,
+        size_t readPos, float g) {
+        return sig_DelayLine_allpass(self, sample, readPos, g);
+    }
+
+    float DelayLine_linearAllpass(struct sig_DelayLine* self,
+        float sample, float readPos, float g) {
+        return sig_DelayLine_linearAllpass(self, sample, readPos, g);
+    }
+
+    float DelayLine_cubicAllpass(struct sig_DelayLine* self, float sample,
+        float readPos, float g) {
+        return sig_DelayLine_cubicAllpass(self, sample, readPos, g);
+    }
+
+    void DelayLine_destroy(struct sig_Allocator* allocator,
+        struct sig_DelayLine* self) {
+        sig_DelayLine_destroy(allocator, self);
+    }
+
+    float linearXFade(float left, float right, float mix) {
+        return sig_linearXFade(left, right, mix);
+    }
+
+    void SingleMonoOutput_newAudioBlocks(
+        struct sig_Allocator* allocator,
+        struct sig_AudioSettings* audioSettings,
+        struct sig_dsp_Signal_SingleMonoOutput* outputs) {
+        return sig_dsp_Signal_SingleMonoOutput_newAudioBlocks(allocator,
+            audioSettings, outputs);
+    }
+
+    void SingleMonoOutput_destroyAudioBlocks(
+        struct sig_Allocator* allocator,
+        struct sig_dsp_Signal_SingleMonoOutput* outputs) {
+        return sig_dsp_Signal_SingleMonoOutput_destroyAudioBlocks(allocator,
+            outputs);
     }
 
     ~Signaletic() {}


### PR DESCRIPTION
Most of these bindings haven't been exercised yet beyond the Signaletic unit tests (which lack adequate coverage) and the two minimal wasm examples. 

More examples that use these bindings should be implemented as part of #62.